### PR TITLE
Run ParseTreeTestCase tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,8 +14,13 @@ namespace :test do
     t.warning = true
   end
 
-  task :run => [:unit, :end_to_end]
+  Rake::TestTask.new(:pt_testcase) do |t|
+    t.libs = ['lib']
+    t.test_files = FileList['test/pt_testcase/*_test.rb']
+    t.warning = true
+  end
 
+  task :run => [:unit, :end_to_end, :pt_testcase]
 end
 
 desc 'Alias to test:run'

--- a/test/pt_testcase/pt_test.rb
+++ b/test/pt_testcase/pt_test.rb
@@ -1,0 +1,31 @@
+require File.expand_path('../test_helper.rb', File.dirname(__FILE__))
+require 'pt_testcase'
+
+class RipperRubyParser::Parser
+  def process input
+    parse input
+  end
+end
+
+class RubyParserTestCase < ParseTreeTestCase
+  def self.previous key
+    "Ruby"
+  end
+
+  def self.generate_test klass, node, data, input_name, output_name
+    return if node.to_s =~ /bmethod|dmethod/
+    return if Array === data['Ruby']
+
+    output_name = "ParseTree"
+
+    super
+  end
+end
+
+class TestRuby19Parser < RubyParserTestCase
+  def setup
+    super
+
+    self.processor = RipperRubyParser::Parser.new
+  end
+end


### PR DESCRIPTION
ParseTreeTestCase (included in sexp_processor) has a ton of very detailed tests for RubyParser and the expected Sexps to be generated for various snippets of Ruby code.

This pull request sets up the rippper_ruby_parser test suite to run them. It will run the 1.8+1.9 tests and also the 1.9 specific tests, but not the few 1.8-specific tests. Current results are:

388 tests, 1837 assertions, 57 failures, 8 errors, 6 skips

It would be great to get ripper_ruby_parser passing the rest of these tests, as that would come as close as possible to guarantee RubyParser backwards compatibility. If anyone is interested in doing that work, I'd be up for sponsoring it!

-Bryan
