### PR TITLE
Handle negated match condition

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
@@ -25,17 +25,20 @@ module RipperRubyParser
                               nil)
       end
 
-      def process_unless_mod exp
-        _, cond, truepart = exp.shift 3
-        s(:if, handle_condition(cond), nil, process(truepart))
-      end
-
       def process_unless exp
         _, cond, truepart, falsepart = exp.shift 4
 
         construct_conditional(handle_condition(cond),
                               process(falsepart),
                               wrap_in_block(map_body(truepart)))
+      end
+
+      def process_unless_mod exp
+        _, cond, truepart = exp.shift 3
+
+        construct_conditional(handle_condition(cond),
+                              nil,
+                              process(truepart))
       end
 
       def process_case exp

--- a/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
@@ -4,9 +4,16 @@ module RipperRubyParser
       def process_if exp
         _, cond, truepart, falsepart = exp.shift 4
 
-        s(:if, handle_condition(cond),
-          wrap_in_block(map_body(truepart)),
-          process(falsepart))
+        cond = handle_condition(cond)
+        truepart = wrap_in_block(map_body(truepart))
+        falsepart = process(falsepart)
+
+        if cond.sexp_type == :not
+          _, inner = cond
+          s(:if, inner, falsepart, truepart)
+        else
+          s(:if, cond, truepart, falsepart)
+        end
       end
 
       def process_elsif exp

--- a/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
@@ -8,12 +8,7 @@ module RipperRubyParser
         truepart = wrap_in_block(map_body(truepart))
         falsepart = process(falsepart)
 
-        if cond.sexp_type == :not
-          _, inner = cond
-          s(:if, inner, falsepart, truepart)
-        else
-          s(:if, cond, truepart, falsepart)
-        end
+        construct_conditional(cond, truepart, falsepart)
       end
 
       def process_elsif exp
@@ -36,10 +31,12 @@ module RipperRubyParser
 
       def process_unless exp
         _, cond, truepart, falsepart = exp.shift 4
-        s(:if,
-          handle_condition(cond),
-          process(falsepart),
-          wrap_in_block(map_body(truepart)))
+
+        cond = handle_condition(cond)
+        truepart = wrap_in_block(map_body(truepart))
+        falsepart = process(falsepart)
+
+        construct_conditional(cond, falsepart, truepart)
       end
 
       def process_case exp
@@ -88,6 +85,15 @@ module RipperRubyParser
           s(:flip3, *cond[1..-1])
         else
           cond
+        end
+      end
+
+      def construct_conditional(cond, truepart, falsepart)
+        if cond.sexp_type == :not
+          _, inner = cond
+          s(:if, inner, falsepart, truepart)
+        else
+          s(:if, cond, truepart, falsepart)
         end
       end
     end

--- a/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
@@ -4,11 +4,9 @@ module RipperRubyParser
       def process_if exp
         _, cond, truepart, falsepart = exp.shift 4
 
-        cond = handle_condition(cond)
-        truepart = wrap_in_block(map_body(truepart))
-        falsepart = process(falsepart)
-
-        construct_conditional(cond, truepart, falsepart)
+        construct_conditional(handle_condition(cond),
+                              wrap_in_block(map_body(truepart)),
+                              process(falsepart))
       end
 
       def process_elsif exp
@@ -21,7 +19,10 @@ module RipperRubyParser
 
       def process_if_mod exp
         _, cond, truepart = exp.shift 3
-        s(:if, handle_condition(cond), process(truepart), nil)
+
+        construct_conditional(handle_condition(cond),
+                              process(truepart),
+                              nil)
       end
 
       def process_unless_mod exp
@@ -32,11 +33,9 @@ module RipperRubyParser
       def process_unless exp
         _, cond, truepart, falsepart = exp.shift 4
 
-        cond = handle_condition(cond)
-        truepart = wrap_in_block(map_body(truepart))
-        falsepart = process(falsepart)
-
-        construct_conditional(cond, falsepart, truepart)
+        construct_conditional(handle_condition(cond),
+                              process(falsepart),
+                              wrap_in_block(map_body(truepart)))
       end
 
       def process_case exp

--- a/lib/ripper_ruby_parser/sexp_handlers/loops.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/loops.rb
@@ -10,7 +10,17 @@ module RipperRubyParser
       end
 
       def process_while exp
-        handle_conditional_loop(:while, exp)
+        _, cond, block = exp.shift 3
+
+        cond = process(cond)
+        body = wrap_in_block(map_body(block))
+
+        if cond.sexp_type == :not
+          _, inner = cond
+          s(:until, inner, body, true)
+        else
+          s(:while, cond, body, true)
+        end
       end
 
       def process_while_mod exp

--- a/lib/ripper_ruby_parser/sexp_handlers/loops.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/loops.rb
@@ -6,7 +6,7 @@ module RipperRubyParser
       end
 
       def process_until_mod exp
-        handle_conditional_loop_mod(:until, exp)
+        handle_conditional_loop_mod :until, :while, exp
       end
 
       def process_while exp
@@ -14,7 +14,7 @@ module RipperRubyParser
       end
 
       def process_while_mod exp
-        handle_conditional_loop_mod(:while, exp)
+        handle_conditional_loop_mod :while, :until, exp
       end
 
       def process_for exp
@@ -36,25 +36,31 @@ module RipperRubyParser
       end
 
       def handle_conditional_loop type, negated_type, exp
-        _, cond, block = exp.shift 3
+        _, cond, body = exp.shift 3
 
-        cond = process(cond)
-        body = wrap_in_block(map_body(block))
-
-        if cond.sexp_type == :not
-          _, inner = cond
-          s(negated_type, inner, body, true)
-        else
-          s(type, cond, body, true)
-        end
+        construct_conditional_loop(type, negated_type,
+                                   process(cond),
+                                   wrap_in_block(map_body(body)),
+                                   true)
       end
 
-      def handle_conditional_loop_mod type, exp
-        _, cond, block = exp.shift 3
+      def handle_conditional_loop_mod type, negated_type, exp
+        _, cond, body = exp.shift 3
 
-        check_at_start = check_at_start?(block)
+        check_at_start = check_at_start?(body)
+        construct_conditional_loop(type, negated_type,
+                                   process(cond),
+                                   process(body),
+                                   check_at_start)
+      end
 
-        s(type, process(cond), process(block), check_at_start)
+      def construct_conditional_loop(type, negated_type, cond, body, check_at_start)
+        if cond.sexp_type == :not
+          _, inner = cond
+          s(negated_type, inner, body, check_at_start)
+        else
+          s(type, cond, body, check_at_start)
+        end
       end
     end
   end

--- a/test/unit/parser_conditionals_test.rb
+++ b/test/unit/parser_conditionals_test.rb
@@ -98,7 +98,7 @@ describe RipperRubyParser::Parser do
                               nil)
       end
 
-      it 'converts negative match operator by swapping effects' do
+      it 'handles negative match operator' do
         'if foo !~ bar; baz; else; qux; end'.
           must_be_parsed_as s(:if,
                               s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
@@ -139,6 +139,14 @@ describe RipperRubyParser::Parser do
                               s(:call, nil, :foo),
                               nil)
       end
+
+      it 'handles negative match operator' do
+        'baz if foo !~ bar'.
+          must_be_parsed_as s(:if,
+                              s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
+                              nil,
+                              s(:call, nil, :baz))
+      end
     end
 
     describe 'for regular unless' do
@@ -173,7 +181,7 @@ describe RipperRubyParser::Parser do
                               s(:call, nil, :bar))
       end
 
-      it 'converts negative match operator by swapping effects' do
+      it 'handles negative match operator' do
         'unless foo !~ bar; baz; else; qux; end'.
           must_be_parsed_as s(:if,
                               s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),

--- a/test/unit/parser_conditionals_test.rb
+++ b/test/unit/parser_conditionals_test.rb
@@ -97,6 +97,14 @@ describe RipperRubyParser::Parser do
                               s(:call, nil, :baz),
                               nil)
       end
+
+      it 'converts negative match operator by swapping effects' do
+        'if foo !~ bar; baz; else; qux; end'.
+          must_be_parsed_as s(:if,
+                              s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
+                              s(:call, nil, :qux),
+                              s(:call, nil, :baz))
+      end
     end
 
     describe 'for postfix if' do

--- a/test/unit/parser_conditionals_test.rb
+++ b/test/unit/parser_conditionals_test.rb
@@ -172,6 +172,14 @@ describe RipperRubyParser::Parser do
                               nil,
                               s(:call, nil, :bar))
       end
+
+      it 'converts negative match operator by swapping effects' do
+        'unless foo !~ bar; baz; else; qux; end'.
+          must_be_parsed_as s(:if,
+                              s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
+                              s(:call, nil, :baz),
+                              s(:call, nil, :qux))
+      end
     end
 
     describe 'for postfix unless' do

--- a/test/unit/parser_conditionals_test.rb
+++ b/test/unit/parser_conditionals_test.rb
@@ -214,6 +214,14 @@ describe RipperRubyParser::Parser do
                               nil,
                               s(:call, nil, :foo))
       end
+
+      it 'handles negative match operator' do
+        'baz unless foo !~ bar'.
+          must_be_parsed_as s(:if,
+                              s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
+                              s(:call, nil, :baz),
+                              nil)
+      end
     end
 
     describe 'for case block' do

--- a/test/unit/parser_loops_test.rb
+++ b/test/unit/parser_loops_test.rb
@@ -44,6 +44,13 @@ describe RipperRubyParser::Parser do
                               s(:call, s(:call, nil, :bar), :!),
                               s(:call, nil, :foo), true)
       end
+
+      it 'converts a negated match condition to :until' do
+        'while foo !~ bar; baz; end'.
+          must_be_parsed_as s(:until,
+                              s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
+                              s(:call, nil, :baz), true)
+      end
     end
 
     describe 'for the until statement' do

--- a/test/unit/parser_loops_test.rb
+++ b/test/unit/parser_loops_test.rb
@@ -95,6 +95,13 @@ describe RipperRubyParser::Parser do
                               s(:call, s(:call, nil, :bar), :!),
                               s(:call, nil, :foo), true)
       end
+
+      it 'converts a negated match condition to :while' do
+        'until foo !~ bar; baz; end'.
+          must_be_parsed_as s(:while,
+                              s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
+                              s(:call, nil, :baz), true)
+      end
     end
   end
 end

--- a/test/unit/parser_loops_test.rb
+++ b/test/unit/parser_loops_test.rb
@@ -51,6 +51,13 @@ describe RipperRubyParser::Parser do
                               s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
                               s(:call, nil, :baz), true)
       end
+
+      it 'converts a negated match condition to :until in the postfix case' do
+        'baz while foo !~ bar'.
+          must_be_parsed_as s(:until,
+                              s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
+                              s(:call, nil, :baz), true)
+      end
     end
 
     describe 'for the until statement' do
@@ -98,6 +105,13 @@ describe RipperRubyParser::Parser do
 
       it 'converts a negated match condition to :while' do
         'until foo !~ bar; baz; end'.
+          must_be_parsed_as s(:while,
+                              s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
+                              s(:call, nil, :baz), true)
+      end
+
+      it 'converts a negated match condition to :while in the postfix case' do
+        'baz until foo !~ bar'.
           must_be_parsed_as s(:while,
                               s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
                               s(:call, nil, :baz), true)

--- a/test/unit/parser_loops_test.rb
+++ b/test/unit/parser_loops_test.rb
@@ -3,6 +3,20 @@ require File.expand_path('../test_helper.rb', File.dirname(__FILE__))
 describe RipperRubyParser::Parser do
   describe '#parse' do
     describe 'for the while statement' do
+      it 'works with do' do
+        'while foo do; bar; end'.
+          must_be_parsed_as s(:while,
+                              s(:call, nil, :foo),
+                              s(:call, nil, :bar), true)
+      end
+
+      it 'works without do' do
+        'while foo; bar; end'.
+          must_be_parsed_as s(:while,
+                              s(:call, nil, :foo),
+                              s(:call, nil, :bar), true)
+      end
+
       it 'works in the single-line postfix case' do
         'foo while bar'.
           must_be_parsed_as s(:while,
@@ -33,6 +47,34 @@ describe RipperRubyParser::Parser do
     end
 
     describe 'for the until statement' do
+      it 'works in the prefix block case with do' do
+        'until foo do; bar; end'.
+          must_be_parsed_as s(:until,
+                              s(:call, nil, :foo),
+                              s(:call, nil, :bar), true)
+      end
+
+      it 'works in the prefix block case without do' do
+        'until foo; bar; end'.
+          must_be_parsed_as s(:until,
+                              s(:call, nil, :foo),
+                              s(:call, nil, :bar), true)
+      end
+
+      it 'works in the single-line postfix case' do
+        'foo until bar'.
+          must_be_parsed_as s(:until,
+                              s(:call, nil, :bar),
+                              s(:call, nil, :foo), true)
+      end
+
+      it 'works in the block postfix case' do
+        'begin; foo; end until bar'.
+          must_be_parsed_as s(:until,
+                              s(:call, nil, :bar),
+                              s(:call, nil, :foo), false)
+      end
+
       it 'handles a negative condition' do
         'until not foo; bar; end'.
           must_be_parsed_as s(:until,

--- a/test/unit/parser_test.rb
+++ b/test/unit/parser_test.rb
@@ -106,52 +106,6 @@ describe RipperRubyParser::Parser do
       end
     end
 
-    describe 'for the until statement' do
-      it 'works in the prefix block case with do' do
-        'until foo do; bar; end'.
-          must_be_parsed_as s(:until,
-                              s(:call, nil, :foo),
-                              s(:call, nil, :bar), true)
-      end
-
-      it 'works in the prefix block case without do' do
-        'until foo; bar; end'.
-          must_be_parsed_as s(:until,
-                              s(:call, nil, :foo),
-                              s(:call, nil, :bar), true)
-      end
-
-      it 'works in the single-line postfix case' do
-        'foo until bar'.
-          must_be_parsed_as s(:until,
-                              s(:call, nil, :bar),
-                              s(:call, nil, :foo), true)
-      end
-
-      it 'works in the block postfix case' do
-        'begin; foo; end until bar'.
-          must_be_parsed_as s(:until,
-                              s(:call, nil, :bar),
-                              s(:call, nil, :foo), false)
-      end
-    end
-
-    describe 'for the while statement' do
-      it 'works with do' do
-        'while foo do; bar; end'.
-          must_be_parsed_as s(:while,
-                              s(:call, nil, :foo),
-                              s(:call, nil, :bar), true)
-      end
-
-      it 'works without do' do
-        'while foo; bar; end'.
-          must_be_parsed_as s(:while,
-                              s(:call, nil, :foo),
-                              s(:call, nil, :bar), true)
-      end
-    end
-
     describe 'for the for statement' do
       it 'works with do' do
         'for foo in bar do; baz; end'.


### PR DESCRIPTION
RubyParser converts `!~` in several conditonals into `=~` with the opposite condtional. This PR updates RipperRubyParser to match this behavior.

Curiously, RubyParser does no conversion in the `elsif` case at the moment.