### PR TITLE
Fix handling of empty string concatenation

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/literals.rb
@@ -48,7 +48,7 @@ module RipperRubyParser
           right
         else # Expecting left.sexp_type == :dstr
           _, first, *rest = right
-          left.push s(:str, first) unless first.empty?
+          left.push s(:str, first) if !first.empty? || rest.empty?
           left.push(*rest)
           left
         end

--- a/test/unit/parser_literals_test.rb
+++ b/test/unit/parser_literals_test.rb
@@ -315,12 +315,22 @@ describe RipperRubyParser::Parser do
                                 s(:evstr, s(:call, nil, :baz)))
         end
 
-        it 'performs the concatenation when the left string has interpolations' do
-          "\"foo\#{bar}\" \"baz\"".
-            must_be_parsed_as s(:dstr,
-                                'foo',
-                                s(:evstr, s(:call, nil, :bar)),
-                                s(:str, 'baz'))
+        describe 'when the left string has interpolations' do
+          it 'performs the concatenation' do
+            "\"foo\#{bar}\" \"baz\"".
+              must_be_parsed_as s(:dstr,
+                                  'foo',
+                                  s(:evstr, s(:call, nil, :bar)),
+                                  s(:str, 'baz'))
+          end
+
+          it 'performs the concatenation with an empty string' do
+            "\"foo\#{bar}\" \"\"".
+              must_be_parsed_as s(:dstr,
+                                  'foo',
+                                  s(:evstr, s(:call, nil, :bar)),
+                                  s(:str, ''))
+          end
         end
 
         describe 'when both strings have interpolations' do


### PR DESCRIPTION
Handle the case of concatenating an empty string to the right of an interpolated string.