### PR TITLE
Improve explicit documenting of public API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@ ripper_ruby_parser-*.gem
 coverage/
 .bundle/
 bin/
+.yardoc/
+doc/*
+!doc/dependency_decisions.yml
 tmp/

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -4,6 +4,8 @@ require 'ripper_ruby_parser/syntax_error'
 module RipperRubyParser
   # Variant of Ripper's SexpBuilderPP parser class that inserts comments as
   # Sexps into the built parse tree.
+  #
+  # @api private
   class CommentingRipperParser < Ripper::SexpBuilderPP
     def initialize(*args)
       super

--- a/lib/ripper_ruby_parser/parser.rb
+++ b/lib/ripper_ruby_parser/parser.rb
@@ -5,6 +5,8 @@ module RipperRubyParser
   # Main parser class. Brings together Ripper and our
   # RipperRubyParser::SexpProcessor.
   class Parser
+
+    # @api private
     attr_accessor :extra_compatible
 
     def initialize

--- a/lib/ripper_ruby_parser/sexp_handlers.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers.rb
@@ -14,6 +14,8 @@ require 'ripper_ruby_parser/sexp_handlers/operators'
 
 module RipperRubyParser
   # Umbrella module for handlers of particular sexp types
+  #
+  # @api private
   module SexpHandlers
     def self.included(base)
       base.class_eval do

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -3,6 +3,8 @@ require 'ripper_ruby_parser/sexp_handlers'
 
 module RipperRubyParser
   # Processes the sexp created by Ripper to what RubyParser would produce.
+  #
+  # @api private
   class SexpProcessor < ::SexpProcessor
     attr_reader :filename
     attr_reader :extra_compatible


### PR DESCRIPTION
The public API was already documented in the README, but this explicitly marks the non-public API in the documentation as generated by YARD.