### PR TITLE
Process line numbers only once per parse run

### DIFF
--- a/lib/ripper_ruby_parser/parser.rb
+++ b/lib/ripper_ruby_parser/parser.rb
@@ -15,7 +15,29 @@ module RipperRubyParser
       if result == s(:void_stmt)
         nil
       else
+        trickle_up_line_numbers result
+        trickle_down_line_numbers result
         result
+      end
+    end
+
+    private
+
+    def trickle_up_line_numbers(exp)
+      exp.each do |sub_exp|
+        if sub_exp.is_a? Sexp
+          trickle_up_line_numbers sub_exp
+          exp.line ||= sub_exp.line
+        end
+      end
+    end
+
+    def trickle_down_line_numbers(exp)
+      exp.each do |sub_exp|
+        if sub_exp.is_a? Sexp
+          sub_exp.line ||= exp.line
+          trickle_down_line_numbers sub_exp
+        end
       end
     end
   end

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -36,14 +36,6 @@ module RipperRubyParser
       @in_method_body = false
     end
 
-    def process(exp)
-      return nil if exp.nil?
-
-      result = super
-      trickle_up_line_numbers result
-      trickle_down_line_numbers result
-    end
-
     include SexpHandlers
 
     def process_program(exp)


### PR DESCRIPTION
This results in a massive speed-up when parsing real-world sized sources.