### PR TITLE
(Almost) no typeless sexps

### DIFF
--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -66,6 +66,14 @@ module RipperRubyParser
       list << [:dyna_symbol, [elem]]
     end
 
+    def on_stmts_new
+      [:stmts]
+    end
+
+    def on_stmts_add(list, elem)
+      list << elem
+    end
+
     def on_symbols_new
       [:symbols]
     end

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -66,6 +66,14 @@ module RipperRubyParser
       list << elem
     end
 
+    def on_mlhs_new
+      [:mlhs]
+    end
+
+    def on_mlhs_add(list, elem)
+      list << elem
+    end
+
     def on_qsymbols_new
       [:symbols]
     end

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -83,7 +83,7 @@ module RipperRubyParser
     end
 
     def on_qsymbols_new
-      [:symbols]
+      [:qsymbols]
     end
 
     def on_qsymbols_add(list, elem)

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -58,6 +58,14 @@ module RipperRubyParser
       commentize(:def, super)
     end
 
+    def on_args_new
+      [:args]
+    end
+
+    def on_args_add(list, elem)
+      list << elem
+    end
+
     def on_qsymbols_new
       [:symbols]
     end

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -102,6 +102,14 @@ module RipperRubyParser
       end
     end
 
+    def on_xstring_new
+      [:xstring]
+    end
+
+    def on_xstring_add(list, elem)
+      list << elem
+    end
+
     def on_op(token)
       @seen_space = false
       super

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -62,8 +62,12 @@ module RipperRubyParser
       super list, [:dyna_symbol, [elem]]
     end
 
+    def on_symbols_new
+      [:symbols]
+    end
+
     def on_symbols_add(list, elem)
-      super list, [:dyna_symbol, elem]
+      list << [:dyna_symbol, elem]
     end
 
     def on_words_new

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -58,8 +58,12 @@ module RipperRubyParser
       commentize(:def, super)
     end
 
+    def on_qsymbols_new
+      [:symbols]
+    end
+
     def on_qsymbols_add(list, elem)
-      super list, [:dyna_symbol, [elem]]
+      list << [:dyna_symbol, [elem]]
     end
 
     def on_symbols_new

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -74,6 +74,14 @@ module RipperRubyParser
       list << elem
     end
 
+    def on_mrhs_new
+      [:mrhs]
+    end
+
+    def on_mrhs_add(list, elem)
+      list << elem
+    end
+
     def on_qsymbols_new
       [:symbols]
     end

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -66,11 +66,15 @@ module RipperRubyParser
       super list, [:dyna_symbol, elem]
     end
 
+    def on_words_new
+      [:words]
+    end
+
     def on_words_add(list, elem)
       if elem.count == 1
-        super
+        list << elem
       else
-        super list, [:string_content, *elem]
+        list << [:string_content, *elem]
       end
     end
 

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -98,6 +98,14 @@ module RipperRubyParser
       list << [:dyna_symbol, elem]
     end
 
+    def on_word_new
+      [:word]
+    end
+
+    def on_word_add(list, elem)
+      list << elem
+    end
+
     def on_words_new
       [:words]
     end

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -82,6 +82,14 @@ module RipperRubyParser
       list << [:dyna_symbol, [elem]]
     end
 
+    def on_regexp_new
+      [:regexp]
+    end
+
+    def on_regexp_add(list, elem)
+      list << elem
+    end
+
     def on_stmts_new
       [:stmts]
     end

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -90,7 +90,16 @@ module RipperRubyParser
       list << [:dyna_symbol, [elem]]
     end
 
+    def on_qwords_new
+      [:qwords]
+    end
+
+    def on_qwords_add(list, elem)
+      list << elem
+    end
+
     def on_regexp_new
+
       [:regexp]
     end
 

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -74,6 +74,14 @@ module RipperRubyParser
       list << elem
     end
 
+    def on_string_new
+      [:string]
+    end
+
+    def on_string_add(list, elem)
+      list << elem
+    end
+
     def on_symbols_new
       [:symbols]
     end

--- a/lib/ripper_ruby_parser/sexp_handlers/arguments.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/arguments.rb
@@ -4,9 +4,9 @@ module RipperRubyParser
     module Arguments
       def process_args_add_block(exp)
         _, regular, block = exp.shift 3
-        args = handle_potentially_typeless_sexp(regular)
+        args = process(regular)
         args << s(:block_pass, process(block)) if block
-        s(:arglist, *args)
+        s(:arglist, *args.sexp_body)
       end
 
       def process_args_add_star(exp)

--- a/lib/ripper_ruby_parser/sexp_handlers/arrays.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/arrays.rb
@@ -6,7 +6,7 @@ module RipperRubyParser
         _, elems = exp.shift 2
         return s(:array) if elems.nil?
         case elems.sexp_type
-        when :words, :symbols, :args
+        when :words, :symbols, :args, :qwords
           s(:array, *handle_array_elements(elems.sexp_body))
         else
           s(:array, *handle_array_elements(elems))

--- a/lib/ripper_ruby_parser/sexp_handlers/arrays.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/arrays.rb
@@ -4,7 +4,13 @@ module RipperRubyParser
     module Arrays
       def process_array(exp)
         _, elems = exp.shift 2
-        s(:array, *handle_array_elements(elems))
+        if elems.nil?
+          s(:array)
+        elsif elems.sexp_type == :words
+          s(:array, *handle_array_elements(elems.sexp_body))
+        else
+          s(:array, *handle_array_elements(elems))
+        end
       end
 
       def process_aref(exp)

--- a/lib/ripper_ruby_parser/sexp_handlers/arrays.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/arrays.rb
@@ -5,12 +5,7 @@ module RipperRubyParser
       def process_array(exp)
         _, elems = exp.shift 2
         return s(:array) if elems.nil?
-        case elems.sexp_type
-        when :words, :symbols, :args, :qwords, :qsymbols
-          s(:array, *handle_array_elements(elems.sexp_body))
-        else
-          s(:array, *handle_array_elements(elems))
-        end
+        s(:array, *handle_array_elements(elems))
       end
 
       def process_aref(exp)

--- a/lib/ripper_ruby_parser/sexp_handlers/arrays.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/arrays.rb
@@ -6,7 +6,7 @@ module RipperRubyParser
         _, elems = exp.shift 2
         return s(:array) if elems.nil?
         case elems.sexp_type
-        when :words, :symbols
+        when :words, :symbols, :args
           s(:array, *handle_array_elements(elems.sexp_body))
         else
           s(:array, *handle_array_elements(elems))

--- a/lib/ripper_ruby_parser/sexp_handlers/arrays.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/arrays.rb
@@ -6,7 +6,7 @@ module RipperRubyParser
         _, elems = exp.shift 2
         return s(:array) if elems.nil?
         case elems.sexp_type
-        when :words, :symbols, :args, :qwords
+        when :words, :symbols, :args, :qwords, :qsymbols
           s(:array, *handle_array_elements(elems.sexp_body))
         else
           s(:array, *handle_array_elements(elems))

--- a/lib/ripper_ruby_parser/sexp_handlers/arrays.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/arrays.rb
@@ -4,9 +4,9 @@ module RipperRubyParser
     module Arrays
       def process_array(exp)
         _, elems = exp.shift 2
-        if elems.nil?
-          s(:array)
-        elsif elems.sexp_type == :words
+        return s(:array) if elems.nil?
+        case elems.sexp_type
+        when :words, :symbols
           s(:array, *handle_array_elements(elems.sexp_body))
         else
           s(:array, *handle_array_elements(elems))

--- a/lib/ripper_ruby_parser/sexp_handlers/assignment.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/assignment.rb
@@ -8,8 +8,8 @@ module RipperRubyParser
         value = process(value)
 
         case value.sexp_type
-        when :splat
-          value = s(:svalue, value)
+        when :mrhs
+          value.sexp_type = :svalue
         when :fake_array
           value = s(:svalue, s(:array, *value.sexp_body))
         end
@@ -38,8 +38,8 @@ module RipperRubyParser
         case right.sexp_type
         when :fake_array
           right[0] = :array
-        when :splat
-          nil # Do nothing
+        when :mrhs
+          right = right[1]
         else
           right = s(:to_ary, right)
         end
@@ -55,13 +55,7 @@ module RipperRubyParser
       end
 
       def process_mrhs_add_star(exp)
-        exp = generic_add_star exp
-
-        if exp.first.is_a? Symbol
-          exp
-        else
-          exp.first
-        end
+        generic_add_star exp
       end
 
       def process_mlhs_add_star(exp)

--- a/lib/ripper_ruby_parser/sexp_handlers/assignment.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/assignment.rb
@@ -28,6 +28,9 @@ module RipperRubyParser
           left.shift
         end
 
+        if left.first == :mlhs
+          left.shift
+        end
         left = create_multiple_assignment_sub_types left
 
         right = process(right)
@@ -65,7 +68,7 @@ module RipperRubyParser
         _, args, splatarg, rest = exp.shift 4
         items = handle_potentially_typeless_sexp args
         items << s(:splat, process(splatarg))
-        rest.each { |arg| items << process(arg) } if rest
+        rest.sexp_body.each { |arg| items << process(arg) } if rest
         items
       end
 
@@ -74,7 +77,13 @@ module RipperRubyParser
 
         items = handle_potentially_typeless_sexp(contents)
 
-        return items if items.first.is_a? Symbol
+        if items.first == :mlhs
+          items.shift
+        end
+
+        if items.first.is_a? Symbol
+          return items
+        end
 
         s(:masgn, s(:array, *create_multiple_assignment_sub_types(items)))
       end

--- a/lib/ripper_ruby_parser/sexp_handlers/assignment.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/assignment.rb
@@ -21,7 +21,7 @@ module RipperRubyParser
       def process_massign(exp)
         _, left, right = exp.shift 3
 
-        left = handle_potentially_typeless_sexp left
+        left = process left
 
         if left.first == :masgn
           left = left[1]
@@ -60,7 +60,7 @@ module RipperRubyParser
 
       def process_mlhs_add_star(exp)
         _, args, splatarg, rest = exp.shift 4
-        items = handle_potentially_typeless_sexp args
+        items = process args
         items << s(:splat, process(splatarg))
         rest.sexp_body.each { |arg| items << process(arg) } if rest
         items
@@ -69,7 +69,7 @@ module RipperRubyParser
       def process_mlhs_paren(exp)
         _, contents = exp.shift 2
 
-        items = handle_potentially_typeless_sexp(contents)
+        items = process(contents)
 
         if items.first == :mlhs
           items.shift

--- a/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
@@ -106,19 +106,21 @@ module RipperRubyParser
 
       def process_next(exp)
         _, args = exp.shift 2
+        args = handle_return_argument_list(args)
         if args.empty?
           s(:next)
         else
-          s(:next, handle_return_argument_list(args))
+          s(:next, args)
         end
       end
 
       def process_break(exp)
         _, args = exp.shift 2
+        args = handle_return_argument_list(args)
         if args.empty?
           s(:break)
         else
-          s(:break, handle_return_argument_list(args))
+          s(:break, args)
         end
       end
 

--- a/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
@@ -56,11 +56,10 @@ module RipperRubyParser
 
         arr = []
         if eclass
-          eclass = handle_potentially_typeless_sexp eclass
           if eclass.first.is_a? Symbol
-            arr += eclass[1..-1]
+            arr += process(eclass).sexp_body
           else
-            arr << eclass[0]
+            arr << process(eclass[0])
           end
         end
 

--- a/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb
@@ -3,9 +3,7 @@ module RipperRubyParser
     # Utility methods used in several of the sexp handler modules
     module HelperMethods
       def handle_potentially_typeless_sexp(exp)
-        if exp.nil?
-          s()
-        elsif exp.first.is_a? Symbol
+        if exp.first.is_a? Symbol
           process(exp)
         else
           exp.map! { |sub_exp| handle_potentially_typeless_sexp(sub_exp) }

--- a/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb
@@ -2,14 +2,6 @@ module RipperRubyParser
   module SexpHandlers
     # Utility methods used in several of the sexp handler modules
     module HelperMethods
-      def handle_potentially_typeless_sexp(exp)
-        if exp.first.is_a? Symbol
-          process(exp)
-        else
-          exp.map! { |sub_exp| handle_potentially_typeless_sexp(sub_exp) }
-        end
-      end
-
       def handle_argument_list(exp)
         process(exp).tap(&:shift)
       end
@@ -46,7 +38,7 @@ module RipperRubyParser
 
       def generic_add_star(exp)
         _, args, splatarg = exp.shift 3
-        items = handle_potentially_typeless_sexp args
+        items = process args
         items << s(:splat, process(splatarg))
         items << process(exp.shift) until exp.empty?
         items
@@ -93,7 +85,7 @@ module RipperRubyParser
       end
 
       def handle_return_argument_list(arglist)
-        args = handle_potentially_typeless_sexp(arglist)
+        args = process(arglist)
         args.shift if [:arglist, :args].include? args.sexp_type
 
         if args.length == 1
@@ -111,9 +103,7 @@ module RipperRubyParser
       end
 
       def handle_array_elements(elems)
-        elems = handle_potentially_typeless_sexp(elems)
-        elems.shift if [:arglist, :args].include? elems.sexp_type
-        elems
+        process(elems).sexp_body
       end
     end
   end

--- a/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb
@@ -67,7 +67,11 @@ module RipperRubyParser
       end
 
       def map_process(list)
-        list.map { |exp| process(exp) }
+        if list.sexp_type == :stmts
+          list.sexp_body.map { |exp| process(exp) }
+        else
+          list.map  { |exp| process(exp) }
+        end
       end
 
       def wrap_in_block(statements)

--- a/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb
@@ -113,13 +113,7 @@ module RipperRubyParser
       def handle_array_elements(elems)
         elems = handle_potentially_typeless_sexp(elems)
         elems.shift if [:arglist, :args].include? elems.sexp_type
-        elems.map do |elem|
-          if elem.first.is_a? Symbol
-            elem
-          else
-            elem.first
-          end
-        end
+        elems
       end
     end
   end

--- a/lib/ripper_ruby_parser/sexp_handlers/literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/literals.rb
@@ -133,13 +133,17 @@ module RipperRubyParser
       end
 
       def internal_process_string_parts(exp)
-        rest = []
+        if exp.first == :xstring
+          process(exp).sexp_body
+        else
+          rest = []
 
-        until exp.empty?
-          part = exp.shift
-          rest << process(part)
+          until exp.empty?
+            part = exp.shift
+            rest << process(part)
+          end
+          rest
         end
-        rest
       end
 
       def extract_unescaped_string_parts(exp)

--- a/lib/ripper_ruby_parser/sexp_handlers/literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/literals.rb
@@ -21,7 +21,13 @@ module RipperRubyParser
 
       def process_string_embexpr(exp)
         _, list = exp.shift 2
-        val = process(list.first)
+
+        if list.sexp_type == :stmts
+          val = process(list.sexp_body.first)
+        else
+          val = process(list.first)
+        end
+
         case val.sexp_type
         when :str
           val

--- a/lib/ripper_ruby_parser/sexp_handlers/literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/literals.rb
@@ -22,11 +22,7 @@ module RipperRubyParser
       def process_string_embexpr(exp)
         _, list = exp.shift 2
 
-        if list.sexp_type == :stmts
-          val = process(list.sexp_body.first)
-        else
-          val = process(list.first)
-        end
+        val = process(list.sexp_body.first)
 
         case val.sexp_type
         when :str

--- a/lib/ripper_ruby_parser/sexp_handlers/literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/literals.rb
@@ -134,16 +134,18 @@ module RipperRubyParser
 
       def internal_process_string_parts(exp)
         if exp.first == :xstring
-          process(exp).sexp_body
-        else
-          rest = []
-
-          until exp.empty?
-            part = exp.shift
-            rest << process(part)
-          end
-          rest
+          exp.shift
+        elsif exp.first == :word
+          exp.shift
         end
+
+        rest = []
+
+        until exp.empty?
+          part = exp.shift
+          rest << process(part)
+        end
+        rest
       end
 
       def extract_unescaped_string_parts(exp)

--- a/lib/ripper_ruby_parser/sexp_handlers/literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/literals.rb
@@ -137,6 +137,8 @@ module RipperRubyParser
           exp.shift
         elsif exp.first == :word
           exp.shift
+        elsif exp.first == :regexp
+          exp.shift
         end
 
         rest = []

--- a/lib/ripper_ruby_parser/sexp_handlers/methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/methods.rb
@@ -32,13 +32,7 @@ module RipperRubyParser
 
       def process_yield(exp)
         _, arglist = exp.shift 2
-        args = handle_potentially_typeless_sexp(arglist)
-        if args.sexp_type == :arglist
-          args.shift
-        elsif args.sexp_type == :args
-          args.shift
-        end
-        s(:yield, *args)
+        s(:yield, *handle_argument_list(arglist))
       end
 
       def process_yield0(exp)

--- a/lib/ripper_ruby_parser/sexp_handlers/methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/methods.rb
@@ -33,7 +33,11 @@ module RipperRubyParser
       def process_yield(exp)
         _, arglist = exp.shift 2
         args = handle_potentially_typeless_sexp(arglist)
-        args.shift if args.sexp_type == :arglist
+        if args.sexp_type == :arglist
+          args.shift
+        elsif args.sexp_type == :args
+          args.shift
+        end
         s(:yield, *args)
       end
 

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -122,11 +122,7 @@ module RipperRubyParser
 
     def process_paren(exp)
       _, body = exp.shift 2
-      if body.empty?
-        s()
-      else
-        process body
-      end
+      process body
     end
 
     def process_comment(exp)

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -65,6 +65,23 @@ module RipperRubyParser
       s(:sclass, process(klass), *class_or_module_body(block))
     end
 
+    def process_stmts(exp)
+      exp.shift
+      statements = []
+      statements << process(exp.shift) until exp.empty?
+      case statements.count
+      when 1
+        first = statements.first
+        if first.sexp_type == :void_stmt
+          s(:nil)
+        else
+          first
+        end
+      else
+        s(:block, *statements)
+      end
+    end
+
     def process_var_ref(exp)
       _, contents = exp.shift 2
       process(contents)

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -124,11 +124,8 @@ module RipperRubyParser
       _, body = exp.shift 2
       if body.empty?
         s()
-      elsif body.first.is_a? Symbol
-        process body
       else
-        body.map! { |it| convert_void_stmt_to_nil process it }
-        safe_wrap_in_block body
+        process body
       end
     end
 
@@ -264,14 +261,6 @@ module RipperRubyParser
           sub_exp.line ||= exp.line
           trickle_down_line_numbers sub_exp
         end
-      end
-    end
-
-    def convert_void_stmt_to_nil(sexp)
-      if sexp == s(:void_stmt)
-        s(:nil)
-      else
-        sexp
       end
     end
   end

--- a/test/unit/commenting_ripper_parser_test.rb
+++ b/test/unit/commenting_ripper_parser_test.rb
@@ -98,7 +98,8 @@ describe RipperRubyParser::CommentingRipperParser do
       result = parse_with_builder ":'foo'; def bar; end"
       result.must_equal s(:program,
                           s(:stmts,
-                            s(:dyna_symbol, s(s(:@tstring_content, 'foo', s(1, 2)))),
+                            s(:dyna_symbol,
+                              s(:xstring, s(:@tstring_content, 'foo', s(1, 2)))),
                             s(:comment,
                               '',
                               s(:def,
@@ -112,7 +113,7 @@ describe RipperRubyParser::CommentingRipperParser do
       result.must_equal s(:program,
                           s(:stmts,
                             s(:dyna_symbol,
-                              s(
+                              s(:xstring,
                                 s(:@tstring_content, 'foo', s(1, 2)),
                                 s(:string_embexpr,
                                   s(:stmts,

--- a/test/unit/commenting_ripper_parser_test.rb
+++ b/test/unit/commenting_ripper_parser_test.rb
@@ -14,103 +14,114 @@ describe RipperRubyParser::CommentingRipperParser do
     it 'produces a comment node surrounding a commented def' do
       result = parse_with_builder "# Foo\ndef foo; end"
       result.must_equal s(:program,
-                          s(s(:comment,
+                          s(:stmts,
+                            s(:comment,
                               "# Foo\n",
                               s(:def,
                                 s(:@ident, 'foo', s(2, 4)),
                                 empty_params_list,
-                                s(:bodystmt, s(s(:void_stmt)), nil, nil, nil)))))
+                                s(:bodystmt, s(:stmts, s(:void_stmt)), nil, nil, nil)))))
     end
 
     it 'produces a blank comment node surrounding a def that has no comment' do
       result = parse_with_builder 'def foo; end'
       result.must_equal s(:program,
-                          s(s(:comment,
+                          s(:stmts,
+                            s(:comment,
                               '',
                               s(:def,
                                 s(:@ident, 'foo', s(1, 4)),
                                 empty_params_list,
-                                s(:bodystmt, s(s(:void_stmt)), nil, nil, nil)))))
+                                s(:bodystmt, s(:stmts, s(:void_stmt)), nil, nil, nil)))))
     end
 
     it 'produces a comment node surrounding a commented class' do
       result = parse_with_builder "# Foo\nclass Foo; end"
       result.must_equal s(:program,
-                          s(s(:comment,
+                          s(:stmts,
+                            s(:comment,
                               "# Foo\n",
                               s(:class,
                                 s(:const_ref, s(:@const, 'Foo', s(2, 6))),
                                 nil,
-                                s(:bodystmt, s(s(:void_stmt)), nil, nil, nil)))))
+                                s(:bodystmt, s(:stmts, s(:void_stmt)), nil, nil, nil)))))
     end
 
     it 'produce a blank comment node surrounding a class that has no comment' do
       result = parse_with_builder 'class Foo; end'
       result.must_equal s(:program,
-                          s(s(:comment,
+                          s(:stmts,
+                            s(:comment,
                               '',
                               s(:class,
                                 s(:const_ref, s(:@const, 'Foo', s(1, 6))),
                                 nil,
-                                s(:bodystmt, s(s(:void_stmt)), nil, nil, nil)))))
+                                s(:bodystmt, s(:stmts, s(:void_stmt)), nil, nil, nil)))))
     end
 
     it 'produces a comment node surrounding a commented module' do
       result = parse_with_builder "# Foo\nmodule Foo; end"
       result.must_equal s(:program,
-                          s(s(:comment,
+                          s(:stmts,
+                            s(:comment,
                               "# Foo\n",
                               s(:module,
                                 s(:const_ref, s(:@const, 'Foo', s(2, 7))),
-                                s(:bodystmt, s(s(:void_stmt)), nil, nil, nil)))))
+                                s(:bodystmt, s(:stmts, s(:void_stmt)), nil, nil, nil)))))
     end
 
     it 'produces a blank comment node surrounding a module that has no comment' do
       result = parse_with_builder 'module Foo; end'
       result.must_equal s(:program,
-                          s(s(:comment,
+                          s(:stmts,
+                            s(:comment,
                               '',
                               s(:module,
                                 s(:const_ref, s(:@const, 'Foo', s(1, 7))),
-                                s(:bodystmt, s(s(:void_stmt)), nil, nil, nil)))))
+                                s(:bodystmt, s(:stmts, s(:void_stmt)), nil, nil, nil)))))
     end
 
     it 'is not confused by a symbol containing a keyword' do
       result = parse_with_builder ':class; def foo; end'
       result.must_equal s(:program,
-                          s(s(:symbol_literal, s(:symbol, s(:@kw, 'class', s(1, 1)))),
+                          s(:stmts,
+                            s(:symbol_literal, s(:symbol, s(:@kw, 'class', s(1, 1)))),
                             s(:comment,
                               '',
                               s(:def,
                                 s(:@ident, 'foo', s(1, 12)),
                                 empty_params_list,
-                                s(:bodystmt, s(s(:void_stmt)), nil, nil, nil)))))
+                                s(:bodystmt, s(:stmts, s(:void_stmt)), nil, nil, nil)))))
     end
 
     it 'is not confused by a dynamic symbol' do
       result = parse_with_builder ":'foo'; def bar; end"
       result.must_equal s(:program,
-                          s(s(:dyna_symbol, s(s(:@tstring_content, 'foo', s(1, 2)))),
+                          s(:stmts,
+                            s(:dyna_symbol, s(s(:@tstring_content, 'foo', s(1, 2)))),
                             s(:comment,
                               '',
                               s(:def,
                                 s(:@ident, 'bar', s(1, 12)),
                                 empty_params_list,
-                                s(:bodystmt, s(s(:void_stmt)), nil, nil, nil)))))
+                                s(:bodystmt, s(:stmts, s(:void_stmt)), nil, nil, nil)))))
     end
 
     it 'is not confused by a dynamic symbol containing a class definition' do
       result = parse_with_builder ":\"foo\#{class Bar;end}\""
       result.must_equal s(:program,
-                          s(s(:dyna_symbol,
-                              s(s(:@tstring_content, 'foo', s(1, 2)),
+                          s(:stmts,
+                            s(:dyna_symbol,
+                              s(
+                                s(:@tstring_content, 'foo', s(1, 2)),
                                 s(:string_embexpr,
-                                  s(s(:comment,
+                                  s(:stmts,
+                                    s(:comment,
                                       '',
                                       s(:class,
                                         s(:const_ref, s(:@const, 'Bar', s(1, 13))),
                                         nil,
-                                        s(:bodystmt, s(s(:void_stmt)), nil, nil, nil)))))))))
+                                        s(:bodystmt, s(:stmts, s(:void_stmt)), nil, nil, nil)))))))))
     end
   end
 end

--- a/test/unit/parser_literals_test.rb
+++ b/test/unit/parser_literals_test.rb
@@ -354,12 +354,12 @@ describe RipperRubyParser::Parser do
     end
 
     describe 'for word list literals' do
-      it 'works for the simle case with %w' do
-        '%W(foo bar)'.
+      it 'works for the simple case with %w' do
+        '%w(foo bar)'.
           must_be_parsed_as s(:array, s(:str, 'foo'), s(:str, 'bar'))
       end
 
-      it 'works for the simle case with %W' do
+      it 'works for the simple case with %W' do
         '%W(foo bar)'.
           must_be_parsed_as s(:array, s(:str, 'foo'), s(:str, 'bar'))
       end

--- a/test/unit/sexp_processor_test.rb
+++ b/test/unit/sexp_processor_test.rb
@@ -246,7 +246,7 @@ describe RipperRubyParser::SexpProcessor do
 
     describe 'for an :array sexp' do
       it 'pulls up the element sexps' do
-        sexp = s(:array, s(s(:foo), s(:bar), s(:baz)))
+        sexp = s(:array, s(:words, s(:foo), s(:bar), s(:baz)))
         result = processor.process sexp
         result.must_equal s(:array, s(:foo_p), s(:bar_p), s(:baz_p))
       end
@@ -264,9 +264,9 @@ describe RipperRubyParser::SexpProcessor do
 
     describe 'for a :when sexp' do
       it 'turns nested :when clauses into a list' do
-        sexp = s(:when, s(s(:foo)), s(s(:bar)),
-                 s(:when, s(s(:foo)), s(s(:bar)),
-                   s(:when, s(s(:foo)), s(s(:bar)), nil)))
+        sexp = s(:when, s(:args, s(:foo)), s(:stmts, s(:bar)),
+                 s(:when, s(:args, s(:foo)), s(:stmts, s(:bar)),
+                   s(:when, s(:args, s(:foo)), s(:stmts, s(:bar)), nil)))
         result = processor.process sexp
         result.must_equal s(s(:when, s(:array, s(:foo_p)), s(:bar_p)),
                             s(:when, s(:array, s(:foo_p)), s(:bar_p)),

--- a/test/unit/sexp_processor_test.rb
+++ b/test/unit/sexp_processor_test.rb
@@ -47,13 +47,13 @@ describe RipperRubyParser::SexpProcessor do
 
     describe 'for an :args_add_block sexp' do
       it 'transforms a one-argument sexp to an :arglist' do
-        sexp = s(:args_add_block, s(s(:foo)), false)
+        sexp = s(:args_add_block, s(:args, s(:foo)), false)
         result = processor.process sexp
         result.must_equal s(:arglist, s(:foo_p))
       end
 
       it 'transforms a multi-argument sexp to an :arglist' do
-        sexp = s(:args_add_block, s(s(:foo), s(:bar)), false)
+        sexp = s(:args_add_block, s(:args, s(:foo), s(:bar)), false)
         result = processor.process sexp
         result.must_equal s(:arglist, s(:foo_p), s(:bar_p))
       end


### PR DESCRIPTION
By default, SexpBuilderPP creates several expressions without type. There are two problems with this:
* SexpProcessor looks at the type to determine when to stop processing. If the 'type' is not a symbol, the comparison used here becomes much heavier.
* RipperRubyParser needs to check in several places whether the passed-in (sub-)expression has a type or not.

The present PR enhances CommentingRipperParser (derived from SexpBuilderPP) to avoid creating untyped expressions, and adjusts the second pass accordingly. As a result, the `handle_potentially_typeless_sexp` helper can be removed.

Some checks for type presence remain and will hopefully be dealt with later.