### PR TITLE
Use lower-level superclass for initial parser

### DIFF
--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -2,11 +2,11 @@ require 'ripper'
 require 'ripper_ruby_parser/syntax_error'
 
 module RipperRubyParser
-  # Variant of Ripper's SexpBuilderPP parser class that inserts comments as
+  # Variant of Ripper's SexpBuilder parser class that inserts comments as
   # Sexps into the built parse tree.
   #
   # @api private
-  class CommentingRipperParser < Ripper::SexpBuilderPP
+  class CommentingRipperParser < Ripper::SexpBuilder
     def initialize(*args)
       super
       @comment = nil


### PR DESCRIPTION
Using this superclass gives more low-level access to the structure created by Ripper. Also, it avoids cleanups from SexpBuilderPP interfering with cleanups in CommentingRipperParser.