### PR TITLE
Improve block handling

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/operators.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/operators.rb
@@ -27,13 +27,13 @@ module RipperRubyParser
         elsif (mapped = BINARY_OPERATOR_MAP[op])
           make_boolean_operator(mapped, left, right)
         else
-          s(:call, process(left), op, process(right))
+          s(:call, handle_operator_argument(left), op, handle_operator_argument(right))
         end
       end
 
       def process_unary(exp)
         _, op, arg = exp.shift 3
-        arg = process(arg)
+        arg = handle_operator_argument(arg)
         op = UNARY_OPERATOR_MAP[op] || op
         s(:call, arg, op)
       end
@@ -62,7 +62,7 @@ module RipperRubyParser
 
       def process_ifop(exp)
         _, cond, truepart, falsepart = exp.shift 4
-        s(:if, process(cond), process(truepart), process(falsepart))
+        s(:if, handle_operator_argument(cond), handle_operator_argument(truepart), handle_operator_argument(falsepart))
       end
 
       private
@@ -89,6 +89,14 @@ module RipperRubyParser
           right = rebalance_binary(s(:binary, middle, op, right))
         end
         s(:binary, left, op, right)
+      end
+
+      def handle_operator_argument(exp)
+        if exp.sexp_type == :begin
+          s(:begin, process(exp))
+        else
+          process(exp)
+        end
       end
     end
   end

--- a/lib/ripper_ruby_parser/sexp_handlers/operators.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/operators.rb
@@ -69,7 +69,7 @@ module RipperRubyParser
 
       def make_boolean_operator(op, left, right)
         _, left, _, right = rebalance_binary(s(:binary, left, op, right))
-        s(op, process(left), process(right))
+        s(op, process(left), handle_operator_argument(right))
       end
 
       def make_regexp_match_operator(op, left, right)

--- a/lib/ripper_ruby_parser/sexp_handlers/operators.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/operators.rb
@@ -17,6 +17,8 @@ module RipperRubyParser
         :"!~" => :=~
       }.freeze
 
+      SHIFT_OPERATORS = [:<<, :>>]
+
       def process_binary(exp)
         _, left, op, right = exp.shift 4
 
@@ -26,6 +28,8 @@ module RipperRubyParser
           s(:not, make_regexp_match_operator(mapped, left, right))
         elsif (mapped = BINARY_OPERATOR_MAP[op])
           make_boolean_operator(mapped, left, right)
+        elsif SHIFT_OPERATORS.include? op
+          s(:call, process(left), op, process(right))
         else
           s(:call, handle_operator_argument(left), op, handle_operator_argument(right))
         end

--- a/test/ripper_ruby_parser/parser_test.rb
+++ b/test/ripper_ruby_parser/parser_test.rb
@@ -35,7 +35,7 @@ describe RipperRubyParser::Parser do
       end
     end
 
-    describe 'for empty brackets' do
+    describe 'for empty parentheses' do
       it 'works with lone ()' do
         '()'.must_be_parsed_as s(:nil)
       end
@@ -280,7 +280,7 @@ describe RipperRubyParser::Parser do
                               s(:nil))
       end
 
-      it 'works with brackets around the parameter list' do
+      it 'works with parentheses around the parameter list' do
         'def foo(bar); end'.
           must_be_parsed_as s(:defn, :foo, s(:args, :bar), s(:nil))
       end
@@ -402,34 +402,34 @@ describe RipperRubyParser::Parser do
     end
 
     describe 'for yield' do
-      it 'works with no arguments and no brackets' do
+      it 'works with no arguments and no parentheses' do
         'yield'.
           must_be_parsed_as s(:yield)
       end
 
-      it 'works with brackets but no arguments' do
+      it 'works with parentheses but no arguments' do
         'yield()'.
           must_be_parsed_as s(:yield)
       end
 
-      it 'works with one argument and no brackets' do
+      it 'works with one argument and no parentheses' do
         'yield foo'.
           must_be_parsed_as s(:yield, s(:call, nil, :foo))
       end
 
-      it 'works with one argument and brackets' do
+      it 'works with one argument and parentheses' do
         'yield(foo)'.
           must_be_parsed_as s(:yield, s(:call, nil, :foo))
       end
 
-      it 'works with multiple arguments and no brackets' do
+      it 'works with multiple arguments and no parentheses' do
         'yield foo, bar'.
           must_be_parsed_as s(:yield,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar))
       end
 
-      it 'works with multiple arguments and brackets' do
+      it 'works with multiple arguments and parentheses' do
         'yield(foo, bar)'.
           must_be_parsed_as s(:yield,
                               s(:call, nil, :foo),
@@ -712,7 +712,7 @@ describe RipperRubyParser::Parser do
                                 s(:call, nil, :qux)))
       end
 
-      it 'works with brackets around the left-hand side' do
+      it 'works with parentheses around the left-hand side' do
         '(foo, bar) = baz'.
           must_be_parsed_as s(:masgn,
                               s(:array, s(:lasgn, :foo), s(:lasgn, :bar)),
@@ -1008,7 +1008,7 @@ describe RipperRubyParser::Parser do
         result.line.must_equal 1
       end
 
-      it 'works for a method call with brackets' do
+      it 'works for a method call with parentheses' do
         result = parser.parse 'foo()'
         result.line.must_equal 1
       end

--- a/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
@@ -125,14 +125,14 @@ describe RipperRubyParser::Parser do
                               s(:call, nil, :bar))
       end
 
-      it 'works for the argument of a unary operator' do
+      it 'keeps :begin for the argument of a unary operator' do
         '- begin; foo; end'.
           must_be_parsed_as s(:call,
                               s(:begin, s(:call, nil, :foo)),
                               :-@)
       end
 
-      it 'works for the first argument of a binary operator' do
+      it 'keeps :begin for the first argument of a binary operator' do
         'begin; bar; end + foo'.
           must_be_parsed_as s(:call,
                               s(:begin, s(:call, nil, :bar)),
@@ -140,7 +140,7 @@ describe RipperRubyParser::Parser do
                               s(:call, nil, :foo))
       end
 
-      it 'works for the second argument of a binary operator' do
+      it 'keeps :begin for the second argument of a binary operator' do
         'foo + begin; bar; end'.
           must_be_parsed_as s(:call,
                               s(:call, nil, :foo),
@@ -148,21 +148,21 @@ describe RipperRubyParser::Parser do
                               s(:begin, s(:call, nil, :bar)))
       end
 
-      it 'works for the first argument of a boolean operator' do
+      it 'does not keep :begin for the first argument of a boolean operator' do
         'begin; bar; end and foo'.
           must_be_parsed_as s(:and,
                               s(:call, nil, :bar),
                               s(:call, nil, :foo))
       end
 
-      it 'works for the second argument of a boolean operator' do
+      it 'keeps :begin for the second argument of a boolean operator' do
         'foo and begin; bar; end'.
           must_be_parsed_as s(:and,
                               s(:call, nil, :foo),
                               s(:begin, s(:call, nil, :bar)))
       end
 
-      it 'works for the first argument of a ternary operator' do
+      it 'keeps :begin for the first argument of a ternary operator' do
         'begin; foo; end ? bar : baz'.
           must_be_parsed_as s(:if,
                               s(:begin, s(:call, nil, :foo)),
@@ -170,7 +170,7 @@ describe RipperRubyParser::Parser do
                               s(:call, nil, :baz))
       end
 
-      it 'works for the second argument of a ternary operator' do
+      it 'keeps :begin for the second argument of a ternary operator' do
         'foo ? begin; bar; end : baz'.
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
@@ -178,7 +178,7 @@ describe RipperRubyParser::Parser do
                               s(:call, nil, :baz))
       end
 
-      it 'works for the third argument of a ternary operator' do
+      it 'keeps :begin for the third argument of a ternary operator' do
         'foo ? bar : begin; baz; end'.
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),

--- a/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
@@ -109,6 +109,70 @@ describe RipperRubyParser::Parser do
       end
     end
 
+    describe 'for begin' do
+      it 'works for an empty begin..end block' do
+        'begin end'.must_be_parsed_as s(:nil)
+      end
+
+      it 'works for a simple begin..end block' do
+        'begin; foo; end'.must_be_parsed_as s(:call, nil, :foo)
+      end
+
+      it 'works for begin..end block with more than one statement' do
+        'begin; foo; bar; end'.
+          must_be_parsed_as s(:block,
+                              s(:call, nil, :foo),
+                              s(:call, nil, :bar))
+      end
+
+      it 'works for the argument of a unary operator' do
+        '- begin; foo; end'.
+          must_be_parsed_as s(:call,
+                              s(:begin, s(:call, nil, :foo)),
+                              :-@)
+      end
+
+      it 'works for the first argument of a binary operator' do
+        'begin; bar; end + foo'.
+          must_be_parsed_as s(:call,
+                              s(:begin, s(:call, nil, :bar)),
+                              :+,
+                              s(:call, nil, :foo))
+      end
+
+      it 'works for the second argument of a binary operator' do
+        'foo + begin; bar; end'.
+          must_be_parsed_as s(:call,
+                              s(:call, nil, :foo),
+                              :+,
+                              s(:begin, s(:call, nil, :bar)))
+      end
+
+      it 'works for the first argument of a ternary operator' do
+        'begin; foo; end ? bar : baz'.
+          must_be_parsed_as s(:if,
+                              s(:begin, s(:call, nil, :foo)),
+                              s(:call, nil, :bar),
+                              s(:call, nil, :baz))
+      end
+
+      it 'works for the second argument of a ternary operator' do
+        'foo ? begin; bar; end : baz'.
+          must_be_parsed_as s(:if,
+                              s(:call, nil, :foo),
+                              s(:begin, s(:call, nil, :bar)),
+                              s(:call, nil, :baz))
+      end
+
+      it 'works for the third argument of a ternary operator' do
+        'foo ? bar : begin; baz; end'.
+          must_be_parsed_as s(:if,
+                              s(:call, nil, :foo),
+                              s(:call, nil, :bar),
+                              s(:begin, s(:call, nil, :baz)))
+      end
+    end
+
     describe 'for rescue/else' do
       it 'works for a block with multiple rescue statements' do
         'begin foo; rescue; bar; rescue; baz; end'.

--- a/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
@@ -148,6 +148,20 @@ describe RipperRubyParser::Parser do
                               s(:begin, s(:call, nil, :bar)))
       end
 
+      it 'works for the first argument of a boolean operator' do
+        'begin; bar; end and foo'.
+          must_be_parsed_as s(:and,
+                              s(:call, nil, :bar),
+                              s(:call, nil, :foo))
+      end
+
+      it 'works for the second argument of a boolean operator' do
+        'foo and begin; bar; end'.
+          must_be_parsed_as s(:and,
+                              s(:call, nil, :foo),
+                              s(:begin, s(:call, nil, :bar)))
+      end
+
       it 'works for the first argument of a ternary operator' do
         'begin; foo; end ? bar : baz'.
           must_be_parsed_as s(:if,

--- a/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
@@ -162,6 +162,22 @@ describe RipperRubyParser::Parser do
                               s(:begin, s(:call, nil, :bar)))
       end
 
+      it 'does not keep :begin for the first argument of a shift operator' do
+        'begin; bar; end << foo'.
+          must_be_parsed_as s(:call,
+                              s(:call, nil, :bar),
+                              :<<,
+                              s(:call, nil, :foo))
+      end
+
+      it 'does not keep :begin for the second argument of a shift operator' do
+        'foo >> begin; bar; end'.
+          must_be_parsed_as s(:call,
+                              s(:call, nil, :foo),
+                              :>>,
+                              s(:call, nil, :bar))
+      end
+
       it 'keeps :begin for the first argument of a ternary operator' do
         'begin; foo; end ? bar : baz'.
           must_be_parsed_as s(:if,

--- a/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
@@ -8,7 +8,7 @@ describe RipperRubyParser::Parser do
           must_be_parsed_as s(:lit, /foo/)
       end
 
-      it 'works for regex literals with escaped right bracket' do
+      it 'works for regex literals with escaped right parenthesis' do
         '/\\)/'.
           must_be_parsed_as s(:lit, /\)/)
       end
@@ -155,12 +155,12 @@ describe RipperRubyParser::Parser do
             must_be_parsed_as s(:str, '\\n')
         end
 
-        it 'works for a representation of a regex literal with escaped right bracket' do
+        it 'works for a representation of a regex literal with escaped right parenthesis' do
           '"/\\\\)/"'.
             must_be_parsed_as s(:str, '/\\)/')
         end
 
-        it 'works for a uselessly escaped right bracket' do
+        it 'works for a uselessly escaped right parenthesis' do
           '"/\\)/"'.
             must_be_parsed_as s(:str, '/)/')
         end

--- a/test/ripper_ruby_parser/sexp_handlers/method_calls_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/method_calls_test.rb
@@ -4,24 +4,24 @@ describe RipperRubyParser::Parser do
   describe '#parse' do
     describe 'for method calls' do
       describe 'without a receiver' do
-        it 'works without brackets' do
+        it 'works without parentheses' do
           'foo bar'.
             must_be_parsed_as s(:call, nil, :foo,
                                 s(:call, nil, :bar))
         end
 
-        it 'works with brackets' do
+        it 'works with parentheses' do
           'foo(bar)'.
             must_be_parsed_as s(:call, nil, :foo,
                                 s(:call, nil, :bar))
         end
 
-        it 'works with an empty parameter list and no brackets' do
+        it 'works with an empty parameter list and no parentheses' do
           'foo'.
             must_be_parsed_as s(:call, nil, :foo)
         end
 
-        it 'works with brackets around an empty parameter list' do
+        it 'works with parentheses around an empty parameter list' do
           'foo()'.
             must_be_parsed_as s(:call, nil, :foo)
         end
@@ -31,7 +31,7 @@ describe RipperRubyParser::Parser do
             must_be_parsed_as s(:call, nil, :foo?)
         end
 
-        it 'works with nested calls without brackets' do
+        it 'works with nested calls without parentheses' do
           'foo bar baz'.
             must_be_parsed_as s(:call, nil, :foo,
                                 s(:call, nil, :bar,
@@ -102,7 +102,7 @@ describe RipperRubyParser::Parser do
       end
 
       describe 'with a receiver' do
-        it 'works without brackets' do
+        it 'works without parentheses' do
           'foo.bar baz'.
             must_be_parsed_as s(:call,
                                 s(:call, nil, :foo),
@@ -110,7 +110,7 @@ describe RipperRubyParser::Parser do
                                 s(:call, nil, :baz))
         end
 
-        it 'works with brackets' do
+        it 'works with parentheses' do
           'foo.bar(baz)'.
             must_be_parsed_as s(:call,
                                 s(:call, nil, :foo),
@@ -118,7 +118,7 @@ describe RipperRubyParser::Parser do
                                 s(:call, nil, :baz))
         end
 
-        it 'works with brackets around a call with no brackets' do
+        it 'works with parentheses around a call with no parentheses' do
           'foo.bar(baz qux)'.
             must_be_parsed_as s(:call,
                                 s(:call, nil, :foo),
@@ -127,7 +127,7 @@ describe RipperRubyParser::Parser do
                                   s(:call, nil, :qux)))
         end
 
-        it 'works with nested calls without brackets' do
+        it 'works with nested calls without parentheses' do
           'foo.bar baz qux'.
             must_be_parsed_as s(:call,
                                 s(:call, nil, :foo),

--- a/test/ripper_ruby_parser/sexp_handlers/operators_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/operators_test.rb
@@ -88,13 +88,22 @@ describe RipperRubyParser::Parser do
                                 s(:call, nil, :baz)))
       end
 
-      it 'handles bracketed :||' do
+      it 'handles :|| with parentheses' do
         '(foo || bar) || baz'.
           must_be_parsed_as s(:or,
                               s(:or,
                                 s(:call, nil, :foo),
                                 s(:call, nil, :bar)),
                               s(:call, nil, :baz))
+      end
+
+      it 'handles nested :|| with parentheses' do
+        'foo || (bar || baz) || qux'.
+          must_be_parsed_as  s(:or,
+                               s(:call, nil, :foo),
+                               s(:or,
+                                 s(:or, s(:call, nil, :bar), s(:call, nil, :baz)),
+                                 s(:call, nil, :qux)))
       end
 
       it 'converts :|| to :or' do
@@ -106,6 +115,17 @@ describe RipperRubyParser::Parser do
 
       it 'handles triple :and' do
         'foo and bar and baz and qux'.
+          must_be_parsed_as s(:and,
+                              s(:call, nil, :foo),
+                              s(:and,
+                                s(:call, nil, :bar),
+                                s(:and,
+                                  s(:call, nil, :baz),
+                                  s(:call, nil, :qux))))
+      end
+
+      it 'handles triple :&&' do
+        'foo && bar && baz && qux'.
           must_be_parsed_as s(:and,
                               s(:call, nil, :foo),
                               s(:and,


### PR DESCRIPTION
RubyParser sometimes emits an extra `:begin` wrapper s-expresion for `block..end` constructs.