### PR TITLE
Treat kwrest args like local variables

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
@@ -54,7 +54,11 @@ module RipperRubyParser
       def process_vcall(exp)
         _, ident = exp.shift 2
         with_position_from_node_symbol(ident) do |method|
-          s(:call, nil, method)
+          if method == @kwrest
+            s(:lvar, method)
+          else
+            s(:call, nil, method)
+          end
         end
       end
 

--- a/lib/ripper_ruby_parser/sexp_handlers/methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/methods.rb
@@ -6,8 +6,14 @@ module RipperRubyParser
         _, ident, params, body = exp.shift 4
         ident, pos = extract_node_symbol_with_position ident
         params = convert_special_args(process(params))
-        with_position(pos,
-                      s(:defn, ident, params, *method_body(body)))
+        last_param = params[-1].to_s
+        old_kwrest = @kwrest
+        @kwrest = if last_param =~ /^\*\*(.*)/
+                    Regexp.last_match[1].to_sym
+                  end
+        body = method_body(body)
+        @kwrest = old_kwrest
+        with_position(pos, s(:defn, ident, params, *body))
       end
 
       def process_defs(exp)

--- a/lib/ripper_ruby_parser/sexp_handlers/methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/methods.rb
@@ -14,11 +14,13 @@ module RipperRubyParser
       def process_defs(exp)
         _, receiver, _, method, params, body = exp.shift 6
         params = convert_special_args(process(params))
+        kwrest = kwrest_param(params)
+        body = with_kwrest(kwrest) { method_body(body) }
 
         s(:defs,
           process(receiver),
           extract_node_symbol(method),
-          params, *method_body(body))
+          params, *body)
       end
 
       def process_return(exp)

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -37,6 +37,7 @@ module RipperRubyParser
       @errors = []
 
       @in_method_body = false
+      @kwrest = nil
     end
 
     include SexpHandlers

--- a/test/samples/misc.rb
+++ b/test/samples/misc.rb
@@ -64,4 +64,13 @@ class Foo
       quuz
     end
   end
+
+  # Using splat and double-splat args
+  def barbaz(*foo, **bar)
+    puts [foo, bar]
+    foo.each do |baz, **qux|
+      puts [foo, bar, baz, qux]
+    end
+    puts [foo, bar]
+  end
 end

--- a/test/samples/misc.rb
+++ b/test/samples/misc.rb
@@ -73,4 +73,12 @@ class Foo
     end
     puts [foo, bar]
   end
+
+  def self.barbaz(*foo, **bar)
+    puts [foo, bar]
+    foo.each do |baz, **qux|
+      puts [foo, bar, baz, qux]
+    end
+    puts [foo, bar]
+  end
 end


### PR DESCRIPTION
Unlike all other arguments, kwrest arguments are not treated as locals by Ripper. This PR adds a hack to change them into locals inside the method body. This should no longer be necessary with Ruby 2.6's version of Ripper.