### PR TITLE
Handle aliasing for method names that are keywords

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/literals.rb
@@ -96,7 +96,11 @@ module RipperRubyParser
 
       def process_symbol_literal(exp)
         _, symbol = exp.shift 2
-        process(symbol)
+        if symbol.sexp_type == :symbol
+          process(symbol)
+        else
+          handle_symbol_content(symbol)
+        end
       end
 
       def process_symbol(exp)

--- a/lib/ripper_ruby_parser/sexp_handlers/methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/methods.rb
@@ -47,7 +47,7 @@ module RipperRubyParser
         _, args = exp.shift 2
 
         args.map! do |sub_exp|
-          s(:undef, make_method_name_literal(sub_exp))
+          s(:undef, process(sub_exp))
         end
 
         if args.size == 1
@@ -60,9 +60,7 @@ module RipperRubyParser
       def process_alias(exp)
         _, left, right = exp.shift 3
 
-        s(:alias,
-          make_method_name_literal(left),
-          make_method_name_literal(right))
+        s(:alias, process(left), process(right))
       end
 
       private
@@ -72,10 +70,6 @@ module RipperRubyParser
         result = yield
         @in_method_body = false
         result
-      end
-
-      def make_method_name_literal(exp)
-        process(exp).tap { |it| it[0] = :lit }
       end
 
       def method_body(exp)

--- a/test/ripper_ruby_parser/parser_test.rb
+++ b/test/ripper_ruby_parser/parser_test.rb
@@ -137,57 +137,6 @@ describe RipperRubyParser::Parser do
       end
     end
 
-    describe 'for the undef statement' do
-      it 'works with a single bareword identifier' do
-        'undef foo'.
-          must_be_parsed_as s(:undef, s(:lit, :foo))
-      end
-
-      it 'works with a single symbol' do
-        'undef :foo'.
-          must_be_parsed_as s(:undef, s(:lit, :foo))
-      end
-
-      it 'works with multiple bareword identifiers' do
-        'undef foo, bar'.
-          must_be_parsed_as s(:block,
-                              s(:undef, s(:lit, :foo)),
-                              s(:undef, s(:lit, :bar)))
-      end
-
-      it 'works with multiple bareword symbols' do
-        'undef :foo, :bar'.
-          must_be_parsed_as s(:block,
-                              s(:undef, s(:lit, :foo)),
-                              s(:undef, s(:lit, :bar)))
-      end
-    end
-
-    describe 'for the alias statement' do
-      it 'works with regular barewords' do
-        'alias foo bar'.
-          must_be_parsed_as s(:alias,
-                              s(:lit, :foo), s(:lit, :bar))
-      end
-
-      it 'works with symbols' do
-        'alias :foo :bar'.
-          must_be_parsed_as s(:alias,
-                              s(:lit, :foo), s(:lit, :bar))
-      end
-
-      it 'works with operator barewords' do
-        'alias + -'.
-          must_be_parsed_as s(:alias,
-                              s(:lit, :+), s(:lit, :-))
-      end
-
-      it 'works with global variables' do
-        'alias $foo $bar'.
-          must_be_parsed_as s(:valias, :$foo, :$bar)
-      end
-    end
-
     describe 'for arguments' do
       it 'works for a simple case with splat' do
         'foo *bar'.

--- a/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
@@ -27,5 +27,61 @@ describe RipperRubyParser::Parser do
                               s(:lvar, :bar))
       end
     end
+
+    describe 'for the alias statement' do
+      it 'works with regular barewords' do
+        'alias foo bar'.
+          must_be_parsed_as s(:alias,
+                              s(:lit, :foo), s(:lit, :bar))
+      end
+
+      it 'works with symbols' do
+        'alias :foo :bar'.
+          must_be_parsed_as s(:alias,
+                              s(:lit, :foo), s(:lit, :bar))
+      end
+
+      it 'works with operator barewords' do
+        'alias + -'.
+          must_be_parsed_as s(:alias,
+                              s(:lit, :+), s(:lit, :-))
+      end
+
+      it 'treats keywords as symbols' do
+        'alias next foo'.
+          must_be_parsed_as s(:alias, s(:lit, :next), s(:lit, :foo))
+      end
+
+      it 'works with global variables' do
+        'alias $foo $bar'.
+          must_be_parsed_as s(:valias, :$foo, :$bar)
+      end
+    end
+
+    describe 'for the undef statement' do
+      it 'works with a single bareword identifier' do
+        'undef foo'.
+          must_be_parsed_as s(:undef, s(:lit, :foo))
+      end
+
+      it 'works with a single symbol' do
+        'undef :foo'.
+          must_be_parsed_as s(:undef, s(:lit, :foo))
+      end
+
+      it 'works with multiple bareword identifiers' do
+        'undef foo, bar'.
+          must_be_parsed_as s(:block,
+                              s(:undef, s(:lit, :foo)),
+                              s(:undef, s(:lit, :bar)))
+      end
+
+      it 'works with multiple bareword symbols' do
+        'undef :foo, :bar'.
+          must_be_parsed_as s(:block,
+                              s(:undef, s(:lit, :foo)),
+                              s(:undef, s(:lit, :bar)))
+      end
+    end
   end
 end

--- a/test/samples/misc.rb
+++ b/test/samples/misc.rb
@@ -161,4 +161,12 @@ class Foo
   rescue *qux => err
     puts err
   end
+
+  # alias
+  alias foo bar
+  alias :foo bar
+  alias :foo :bar
+  alias foo :bar
+  alias :+ -
+  alias next bar
 end


### PR DESCRIPTION
Fixes handling of

```ruby
alias next foo
```