### PR TITLE
Fix handling of begin..end blocks in conditions

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
@@ -14,7 +14,7 @@ module RipperRubyParser
         _, cond, truepart, falsepart = exp.shift 4
 
         s(:if,
-          process(cond),
+          unwrap_begin(process(cond)),
           handle_consequent(truepart),
           handle_consequent(falsepart))
       end

--- a/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
@@ -88,7 +88,7 @@ module RipperRubyParser
         elsif cond.sexp_type == :dot3
           s(:flip3, *cond[1..-1])
         else
-          cond
+          unwrap_begin cond
         end
       end
 

--- a/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
@@ -80,7 +80,7 @@ module RipperRubyParser
       private
 
       def handle_condition(cond)
-        cond = process(cond)
+        cond = unwrap_begin process(cond)
         if (cond.sexp_type == :lit) && cond[1].is_a?(Regexp)
           s(:match, cond)
         elsif cond.sexp_type == :dot2
@@ -88,7 +88,7 @@ module RipperRubyParser
         elsif cond.sexp_type == :dot3
           s(:flip3, *cond[1..-1])
         else
-          unwrap_begin cond
+          cond
         end
       end
 

--- a/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
@@ -81,15 +81,15 @@ module RipperRubyParser
 
       def handle_condition(cond)
         cond = unwrap_begin process(cond)
-        if (cond.sexp_type == :lit) && cond[1].is_a?(Regexp)
-          s(:match, cond)
-        elsif cond.sexp_type == :dot2
-          s(:flip2, *cond[1..-1])
-        elsif cond.sexp_type == :dot3
-          s(:flip3, *cond[1..-1])
-        else
-          cond
+        case cond.sexp_type
+        when :lit
+          return s(:match, cond) if cond[1].is_a?(Regexp)
+        when :dot2
+          return s(:flip2, *cond[1..-1])
+        when :dot3
+          return s(:flip3, *cond[1..-1])
         end
+        cond
       end
 
       def handle_consequent(exp)

--- a/lib/ripper_ruby_parser/sexp_handlers/loops.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/loops.rb
@@ -46,7 +46,7 @@ module RipperRubyParser
         _, cond, body = exp.shift 3
 
         construct_conditional_loop(type, negated_type,
-                                   process(cond),
+                                   unwrap_begin(process(cond)),
                                    unwrap_nil(process(body)),
                                    true)
       end
@@ -56,7 +56,7 @@ module RipperRubyParser
 
         check_at_start = check_at_start?(body)
         construct_conditional_loop(type, negated_type,
-                                   process(cond),
+                                   unwrap_begin(process(cond)),
                                    unwrap_begin(process(body)),
                                    check_at_start)
       end

--- a/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
@@ -123,6 +123,14 @@ describe RipperRubyParser::Parser do
                               s(:call, nil, :foo),
                               s(:call, nil, :bar), nil)
       end
+
+      it 'handles special conditions inside begin..end block' do
+        'if begin foo..bar end; baz; end'.
+          must_be_parsed_as s(:if,
+                              s(:flip2, s(:call, nil, :foo), s(:call, nil, :bar)),
+                              s(:call, nil, :baz),
+                              nil)
+      end
     end
 
     describe 'for postfix if' do

--- a/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
@@ -352,6 +352,17 @@ describe RipperRubyParser::Parser do
                                 s(:call, nil, :quuz),
                                 nil))
       end
+
+      it 'cleans up begin..end block in condition' do
+        'if foo; bar; elsif begin baz end; qux; end'.
+          must_be_parsed_as s(:if,
+                              s(:call, nil, :foo),
+                              s(:call, nil, :bar),
+                              s(:if,
+                                s(:call, nil, :baz),
+                                s(:call, nil, :qux),
+                                nil))
+      end
     end
 
     describe 'for case block' do

--- a/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
@@ -116,6 +116,13 @@ describe RipperRubyParser::Parser do
                               s(:call, nil, :qux),
                               s(:call, nil, :baz))
       end
+
+      it 'cleans up begin..end block in condition' do
+        'if begin foo end; bar; end'.
+          must_be_parsed_as s(:if,
+                              s(:call, nil, :foo),
+                              s(:call, nil, :bar), nil)
+      end
     end
 
     describe 'for postfix if' do
@@ -157,6 +164,13 @@ describe RipperRubyParser::Parser do
                               s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
                               nil,
                               s(:call, nil, :baz))
+      end
+
+      it 'cleans up begin..end block in condition' do
+        'foo if begin bar end'.
+          must_be_parsed_as s(:if,
+                              s(:call, nil, :bar),
+                              s(:call, nil, :foo), nil)
       end
     end
 

--- a/test/ripper_ruby_parser/sexp_handlers/loops_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/loops_test.rb
@@ -58,6 +58,20 @@ describe RipperRubyParser::Parser do
                               s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
                               s(:call, nil, :baz), true)
       end
+
+      it 'cleans up begin..end block in condition' do
+        'while begin foo end; bar; end'.
+          must_be_parsed_as s(:while,
+                              s(:call, nil, :foo),
+                              s(:call, nil, :bar), true)
+      end
+
+      it 'cleans up begin..end block in condition in the postfix case' do
+        'foo while begin bar end'.
+          must_be_parsed_as s(:while,
+                              s(:call, nil, :bar),
+                              s(:call, nil, :foo), true)
+      end
     end
 
     describe 'for the until statement' do
@@ -115,6 +129,20 @@ describe RipperRubyParser::Parser do
           must_be_parsed_as s(:while,
                               s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
                               s(:call, nil, :baz), true)
+      end
+
+      it 'cleans up begin..end block in condition' do
+        'until begin foo end; bar; end'.
+          must_be_parsed_as s(:until,
+                              s(:call, nil, :foo),
+                              s(:call, nil, :bar), true)
+      end
+
+      it 'cleans up begin..end block in condition in the postfix case' do
+        'foo until begin bar end'.
+          must_be_parsed_as s(:until,
+                              s(:call, nil, :bar),
+                              s(:call, nil, :foo), true)
       end
     end
 

--- a/test/samples/conditionals.rb
+++ b/test/samples/conditionals.rb
@@ -4,6 +4,14 @@ if begin foo end
   bar
 end
 
+if begin foo..bar end
+  baz
+end
+
 if foo
 elsif begin bar end
+end
+
+if foo
+elsif begin bar..baz end
 end

--- a/test/samples/conditionals.rb
+++ b/test/samples/conditionals.rb
@@ -1,0 +1,9 @@
+# Conditionals
+
+if begin foo end
+  bar
+end
+
+if foo
+elsif begin bar end
+end

--- a/test/samples/loops.rb
+++ b/test/samples/loops.rb
@@ -1,10 +1,36 @@
 # Loop samples
 
-for foo in bar
+def for_samples
+  for foo in bar
+  end
+
+  for foo, bar in baz
+  end
+
+  for foo, in bar
+  end
 end
 
-for foo, bar in baz
-end
+# begin..end in conditions
+#
+def while_until_samples
+  while begin foo end
+    bar
+  end
 
-for foo, in bar
+  until begin foo end
+    bar
+  end
+
+  while begin foo end do
+    bar
+  end
+
+  until begin foo end do
+    bar
+  end
+
+  foo while begin bar end
+
+  foo until begin bar end
 end

--- a/test/samples/misc.rb
+++ b/test/samples/misc.rb
@@ -171,7 +171,3 @@ class Foo
   alias :+ -
   alias next bar
 end
-
-if begin foo end
-  bar
-end

--- a/test/samples/misc.rb
+++ b/test/samples/misc.rb
@@ -71,6 +71,7 @@ class Foo
     foo = *begin; bar; end
     foo = bar, *begin; baz; end
     foo, bar = *begin; baz; end
+    foo if begin bar end
   end
 
   # Nested do and begin blocks
@@ -169,4 +170,8 @@ class Foo
   alias foo :bar
   alias :+ -
   alias next bar
+end
+
+if begin foo end
+  bar
 end


### PR DESCRIPTION
Fix handling of cases like the following:

```ruby
while begin foo end
  bar
end

if begin foo = bar(baz); foo.qux? end
  quuz
end
```