### PR TITLE
Disregard __LINE__ difference in tests

### DIFF
--- a/test/end_to_end/samples_comparison_test.rb
+++ b/test/end_to_end/samples_comparison_test.rb
@@ -2,36 +2,10 @@ require File.expand_path('../test_helper.rb', File.dirname(__FILE__))
 require 'ruby_parser'
 
 describe 'Using RipperRubyParser and RubyParser' do
-  let :newparser do
-    RipperRubyParser::Parser.new
-  end
-
-  let :oldparser do
-    RubyParser.new
-  end
-
   Dir.glob(File.expand_path('../samples/*.rb', File.dirname(__FILE__))).each do |file|
-    describe "for #{file}" do
-      let :program do
-        File.read file
-      end
-
-      let :original do
-        oldparser.parse program
-      end
-
-      let :imitation do
-        newparser.parse program
-      end
-
-      it 'gives the same result' do
-        formatted(imitation).must_equal formatted(original)
-      end
-
-      it 'gives the same result with comments' do
-        formatted(to_comments(imitation)).
-          must_equal formatted(to_comments(original))
-      end
+    it "gives the same result for #{file}" do
+      program = File.read file
+      program.must_be_parsed_as_before
     end
   end
 end

--- a/test/samples/strings.rb
+++ b/test/samples/strings.rb
@@ -93,3 +93,8 @@ bar baz]
 bar baz]
 %r[fool\\
 bar baz]
+
+eval(<<FOO, __FILE__, __LINE__)
+bar
+baz
+FOO

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,9 +16,7 @@ module MiniTest
     end
 
     def fix_lines(exp)
-      if exp.sexp_type == :lit && exp.line == exp[1]
-        return s(:lit, :__LINE__)
-      end
+      return s(:lit, :__LINE__) if exp.sexp_type == :lit && exp.line == exp[1]
 
       inner = exp.map do |sub_exp|
         if sub_exp.is_a? Sexp

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,22 @@ module MiniTest
       exp.to_s.gsub(/\), /, "),\n")
     end
 
+    def fix_lines(exp)
+      if exp.sexp_type == :lit && exp.line == exp[1]
+        return s(:lit, :__LINE__)
+      end
+
+      inner = exp.map do |sub_exp|
+        if sub_exp.is_a? Sexp
+          fix_lines sub_exp
+        else
+          sub_exp
+        end
+      end
+
+      s(*inner)
+    end
+
     def to_comments(exp)
       inner = exp.map do |sub_exp|
         if sub_exp.is_a? Sexp
@@ -48,6 +64,9 @@ module MiniTest
       newparser = RipperRubyParser::Parser.new
       expected = oldparser.parse code.dup
       result = newparser.parse code
+      expected = to_comments fix_lines expected
+      result = to_comments fix_lines result
+      assert_equal expected, result
       assert_equal formatted(expected), formatted(result)
     end
   end


### PR DESCRIPTION
Ruby_parser has bugs in line numbering, so we don't want to emulate it completely in that aspect. Detect line literals by comparing them with the line annotation so we know that some line number was parsed.