### PR TITLE
Prepare for Ruby 2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ source 'https://rubygems.org'
 gemspec
 
 group :local_development do
-  gem 'irbtools-more'
+  gem 'irbtools'
 end

--- a/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
@@ -142,7 +142,7 @@ module RipperRubyParser
         _, args, statements = exp.shift 3
         old_type = args.sexp_type
         args = convert_special_args(process(args))
-        args = 0 if args == s(:args) && old_type == :params
+        args = nil if args == s(:args) && old_type == :params
         make_iter(s(:call, nil, :lambda),
                   args,
                   safe_unwrap_void_stmt(process(statements)))
@@ -211,6 +211,7 @@ module RipperRubyParser
       end
 
       def make_iter(call, args, stmt)
+        args.pop if args && args.last == s(:excessed_comma)
         args ||= 0
         if stmt.empty?
           s(:iter, call, args)

--- a/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
@@ -25,7 +25,7 @@ module RipperRubyParser
 
       def process_call(exp)
         _, receiver, op, ident = exp.shift 4
-        type = CALL_OP_MAP.fetch op
+        type = map_call_op op
         case ident
         when :call
           s(type, process(receiver), :call)
@@ -46,11 +46,16 @@ module RipperRubyParser
 
       def process_command_call(exp)
         _, receiver, op, ident, arguments = exp.shift 5
-        type = CALL_OP_MAP.fetch op
+        type = map_call_op op
         with_position_from_node_symbol(ident) do |method|
           args = handle_argument_list(arguments)
           s(type, process(receiver), method, *args)
         end
+      end
+
+      def map_call_op(call_op)
+        call_op = call_op.sexp_body.first.to_sym if call_op.is_a? Sexp
+        CALL_OP_MAP.fetch(call_op)
       end
 
       def process_vcall(exp)

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -31,6 +31,7 @@ module RipperRubyParser
       @processors[:@kw] = :process_at_kw
       @processors[:@op] = :process_at_op
       @processors[:@backref] = :process_at_backref
+      @processors[:@period] = :process_at_period
 
       @processors[:@tstring_content] = :process_at_tstring_content
 
@@ -230,6 +231,11 @@ module RipperRubyParser
           s(:back_ref, name.to_sym)
         end
       end
+    end
+
+    def process_at_period(exp)
+      _, period, = exp.shift 3
+      s(:period, period)
     end
 
     private

--- a/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
@@ -128,23 +128,42 @@ describe RipperRubyParser::Parser do
                               s(:args, :bar, :"*baz"))
       end
 
-      it 'works with a double splat argument' do
+      it 'works with a kwrest argument' do
+        expected = if RUBY_VERSION < '2.6.0'
+                     s(:iter,
+                       s(:call, nil, :foo),
+                       s(:args, :"**bar"),
+                       s(:call, nil, :baz,
+                         s(:call, nil, :bar)))
+                   else
+                     s(:iter,
+                       s(:call, nil, :foo),
+                       s(:args, :"**bar"),
+                       s(:call, nil, :baz,
+                         s(:lvar, :bar)))
+                   end
         'foo do |**bar|; baz bar; end'.
-          must_be_parsed_as s(:iter,
-                              s(:call, nil, :foo),
-                              s(:args, :"**bar"),
-                              s(:call, nil, :baz,
-                                s(:call, nil, :bar)))
+          must_be_parsed_as expected
       end
 
-      it 'works with a combination of regular arguments and a splat argument' do
+      it 'works with a combination of regular arguments and a kwrest argument' do
+        expected = if RUBY_VERSION < '2.6.0'
+                     s(:iter,
+                       s(:call, nil, :foo),
+                       s(:args, :bar, :"**baz"),
+                       s(:call, nil, :qux,
+                         s(:lvar, :bar),
+                         s(:call, nil, :baz)))
+                   else
+                     s(:iter,
+                       s(:call, nil, :foo),
+                       s(:args, :bar, :"**baz"),
+                       s(:call, nil, :qux,
+                         s(:lvar, :bar),
+                         s(:lvar, :baz)))
+                   end
         'foo do |bar, **baz|; qux bar, baz; end'.
-          must_be_parsed_as s(:iter,
-                              s(:call, nil, :foo),
-                              s(:args, :bar, :"**baz"),
-                              s(:call, nil, :qux,
-                                s(:lvar, :bar),
-                                s(:call, nil, :baz)))
+          must_be_parsed_as expected
       end
     end
 

--- a/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
@@ -30,16 +30,28 @@ describe RipperRubyParser::Parser do
       end
 
       # NOTE: See https://github.com/seattlerb/ruby_parser/issues/276
-      it 'treats kwargs as a method call in a block with kwargs' do
+      it 'treats kwargs compatibly in a block with kwargs' do
+        expected = if RUBY_VERSION < '2.6.0'
+                     s(:defn, :foo,
+                       s(:args, :"**bar"),
+                       s(:iter,
+                         s(:call, nil, :baz),
+                         s(:args, :"**qux"),
+                         s(:block,
+                           s(:lvar, :bar),
+                           s(:call, nil, :qux))))
+                   else
+                     s(:defn, :foo,
+                       s(:args, :"**bar"),
+                       s(:iter,
+                         s(:call, nil, :baz),
+                         s(:args, :"**qux"),
+                         s(:block,
+                           s(:lvar, :bar),
+                           s(:lvar, :qux))))
+                   end
         'def foo(**bar); baz { |**qux| bar; qux }; end'.
-          must_be_parsed_as s(:defn, :foo,
-                              s(:args, :"**bar"),
-                              s(:iter,
-                                s(:call, nil, :baz),
-                                s(:args, :"**qux"),
-                                s(:block,
-                                  s(:lvar, :bar),
-                                  s(:call, nil, :qux))))
+          must_be_parsed_as expected
       end
 
       it 'works with a method argument with a default value' do


### PR DESCRIPTION
Updates code and tests so unit tests pass with Ruby 2.6. Integration tests do not pass yet due to different handling of kwrest arguments for blocks.