### PR TITLE
Fix kwarg rest handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: ruby
 before_install: gem update --system
 bundler_args: --without local_development
 rvm:
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
   - ruby-head
 matrix:
   allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 * Process embedded documents as comments
 * Handle \u{xxxx} form of unicode escape sequence
-* Specifically treat keyword rest arguments (double spats) as local variables.
-  All other arguments are already treated as such by Ripper, but these are not.
-  A hacky workaround was added to adjust this
+* Treat keyword rest arguments (double spats) as local variables, for blocks
+  and for methods.
+  Versions of Ripper before CRuby 2.6 do not handle these correctly, so
+  RipperRubyParser adds its own accounting of these parameters.
 * Do not unescape heredocs with single quotes. These are heredocs where the
   marker is a single-quoted string
 * Increase compatibility when handling a begin..end block, e.g., as an assigned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@
   parts of strings with interpolations. This behavior is only enabled when
   `#extra_compatible` is set to true
 * Require Ruby 2.3 or higher
-* Compatible with RubyParser 3.12.0
+* Mark as compatible with RubyParser 3.12.0
+* Match RubyParser's handling of block keyword rest arguments.
+  This behavior is only enabled when `#extra_compatible` is set to true
 
 ## 1.4.2 / 2018-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Mark as compatible with RubyParser 3.12.0
 * Match RubyParser's handling of block keyword rest arguments.
   This behavior is only enabled when `#extra_compatible` is set to true
+* Support Ruby 2.6
 
 ## 1.4.2 / 2018-04-03
 
@@ -70,6 +71,7 @@
 * Improve handling of boolean operators with parenthes
 * Improve compatibility for begin..end blocks used as method and operator
   arguments.
+* Support Ruby 2.5
 * Drop support for Ruby 2.0 and 2.1
 * Handle `__ENCODING__` constant.
 

--- a/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
@@ -9,8 +9,9 @@ module RipperRubyParser
         _, args, stmt = block
         call = process(call)
         args = process(args)
-        stmt = safe_unwrap_void_stmt process(stmt)
-        make_iter call, args, stmt
+        kwrest = kwrest_param(args) if args
+        stmt = with_kwrest(kwrest) { process(stmt) }
+        make_iter call, args, safe_unwrap_void_stmt(stmt)
       end
 
       def process_params(exp)

--- a/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
@@ -9,8 +9,8 @@ module RipperRubyParser
         _, args, stmt = block
         call = process(call)
         args = process(args)
-        kwrest = kwrest_param(args) if args && !extra_compatible
-        stmt = with_kwrest(kwrest) { process(stmt) }
+        kwrest = kwrest_param(args) if args
+        stmt = with_block_kwrest(kwrest) { process(stmt) }
         make_iter call, args, safe_unwrap_void_stmt(stmt)
       end
 

--- a/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
@@ -9,7 +9,7 @@ module RipperRubyParser
         _, args, stmt = block
         call = process(call)
         args = process(args)
-        kwrest = kwrest_param(args) if args
+        kwrest = kwrest_param(args) if args && !extra_compatible
         stmt = with_kwrest(kwrest) { process(stmt) }
         make_iter call, args, safe_unwrap_void_stmt(stmt)
       end

--- a/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
@@ -79,7 +79,7 @@ module RipperRubyParser
       def process_vcall(exp)
         _, ident = exp.shift 2
         with_position_from_node_symbol(ident) do |method|
-          if is_kwrest_arg? method
+          if replace_kwrest_arg_call? method
             s(:lvar, method)
           else
             s(:call, nil, method)
@@ -108,6 +108,13 @@ module RipperRubyParser
         args = process(args)
         args.shift
         s(:super, *args)
+      end
+
+      private
+
+      def replace_kwrest_arg_call?(method)
+        is_method_kwrest_arg?(method) ||
+          !extra_compatible && is_block_kwrest_arg?(method)
       end
     end
   end

--- a/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
@@ -113,8 +113,8 @@ module RipperRubyParser
       private
 
       def replace_kwrest_arg_call?(method)
-        is_method_kwrest_arg?(method) ||
-          !extra_compatible && is_block_kwrest_arg?(method)
+        method_kwrest_arg?(method) ||
+          !extra_compatible && block_kwrest_arg?(method)
       end
     end
   end

--- a/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
@@ -79,7 +79,7 @@ module RipperRubyParser
       def process_vcall(exp)
         _, ident = exp.shift 2
         with_position_from_node_symbol(ident) do |method|
-          if @kwrest.include? method
+          if is_kwrest_arg? method
             s(:lvar, method)
           else
             s(:call, nil, method)

--- a/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
@@ -79,7 +79,7 @@ module RipperRubyParser
       def process_vcall(exp)
         _, ident = exp.shift 2
         with_position_from_node_symbol(ident) do |method|
-          if method == @kwrest
+          if @kwrest.include? method
             s(:lvar, method)
           else
             s(:call, nil, method)

--- a/lib/ripper_ruby_parser/sexp_handlers/methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/methods.rb
@@ -140,9 +140,12 @@ module RipperRubyParser
         result
       end
 
-      def is_kwrest_arg?(method)
-        @kwrest.include?(method) ||
-          !extra_compatible && @block_kwrest.include?(method)
+      def is_method_kwrest_arg?(method)
+        @kwrest.include?(method)
+      end
+
+      def is_block_kwrest_arg?(method)
+        @block_kwrest.include?(method)
       end
     end
   end

--- a/lib/ripper_ruby_parser/sexp_handlers/methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/methods.rb
@@ -127,10 +127,9 @@ module RipperRubyParser
       end
 
       def with_kwrest(kwrest)
-        old_kwrest = @kwrest
-        @kwrest = kwrest
+        @kwrest.push kwrest
         result = yield
-        @kwrest = old_kwrest
+        @kwrest.pop
         result
       end
     end

--- a/lib/ripper_ruby_parser/sexp_handlers/methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/methods.rb
@@ -140,11 +140,11 @@ module RipperRubyParser
         result
       end
 
-      def is_method_kwrest_arg?(method)
+      def method_kwrest_arg?(method)
         @kwrest.include?(method)
       end
 
-      def is_block_kwrest_arg?(method)
+      def block_kwrest_arg?(method)
         @block_kwrest.include?(method)
       end
     end

--- a/lib/ripper_ruby_parser/sexp_handlers/methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/methods.rb
@@ -132,6 +132,18 @@ module RipperRubyParser
         @kwrest.pop
         result
       end
+
+      def with_block_kwrest(kwrest)
+        @block_kwrest.push kwrest
+        result = yield
+        @block_kwrest.pop
+        result
+      end
+
+      def is_kwrest_arg?(method)
+        @kwrest.include?(method) ||
+          !extra_compatible && @block_kwrest.include?(method)
+      end
     end
   end
 end

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -41,7 +41,7 @@ module RipperRubyParser
       @errors = []
 
       @in_method_body = false
-      @kwrest = nil
+      @kwrest = []
     end
 
     include SexpHandlers

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -42,6 +42,7 @@ module RipperRubyParser
 
       @in_method_body = false
       @kwrest = []
+      @block_kwrest = []
     end
 
     include SexpHandlers

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -200,7 +200,13 @@ module RipperRubyParser
     end
 
     def process_at_ident(exp)
-      make_identifier(:lvar, exp)
+      with_position_from_node_symbol(exp) do |ident|
+        if replace_kwrest_arg_lvar? ident
+          s(:call, nil, ident)
+        else
+          s(:lvar, ident)
+        end
+      end
     end
 
     def process_at_op(exp)
@@ -269,6 +275,10 @@ module RipperRubyParser
     def make_literal(exp)
       _, val, pos = exp.shift 3
       with_position(pos, s(:lit, yield(val)))
+    end
+
+    def replace_kwrest_arg_lvar?(ident)
+      extra_compatible && @block_kwrest.include?(ident)
     end
   end
 end

--- a/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
@@ -162,21 +162,12 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a kwrest argument' do
-        expected = if RUBY_VERSION < '2.6.0'
-                     s(:iter,
-                       s(:call, nil, :foo),
-                       s(:args, :"**bar"),
-                       s(:call, nil, :baz,
-                         s(:call, nil, :bar)))
-                   else
-                     s(:iter,
-                       s(:call, nil, :foo),
-                       s(:args, :"**bar"),
-                       s(:call, nil, :baz,
-                         s(:lvar, :bar)))
-                   end
         'foo do |**bar|; baz bar; end'.
-          must_be_parsed_as expected
+          must_be_parsed_as s(:iter,
+                              s(:call, nil, :foo),
+                              s(:args, :"**bar"),
+                              s(:call, nil, :baz,
+                                s(:lvar, :bar)))
       end
 
       it 'works with a regular argument after a splat argument' do
@@ -187,23 +178,13 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a combination of regular arguments and a kwrest argument' do
-        expected = if RUBY_VERSION < '2.6.0'
-                     s(:iter,
-                       s(:call, nil, :foo),
-                       s(:args, :bar, :"**baz"),
-                       s(:call, nil, :qux,
-                         s(:lvar, :bar),
-                         s(:call, nil, :baz)))
-                   else
-                     s(:iter,
-                       s(:call, nil, :foo),
-                       s(:args, :bar, :"**baz"),
-                       s(:call, nil, :qux,
-                         s(:lvar, :bar),
-                         s(:lvar, :baz)))
-                   end
         'foo do |bar, **baz|; qux bar, baz; end'.
-          must_be_parsed_as expected
+          must_be_parsed_as s(:iter,
+                              s(:call, nil, :foo),
+                              s(:args, :bar, :"**baz"),
+                              s(:call, nil, :qux,
+                                s(:lvar, :bar),
+                                s(:lvar, :baz)))
       end
     end
 

--- a/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
@@ -29,29 +29,16 @@ describe RipperRubyParser::Parser do
                               s(:lvar, :bar))
       end
 
-      # NOTE: See https://github.com/seattlerb/ruby_parser/issues/276
-      it 'treats kwargs compatibly in a block with kwargs' do
-        expected = if RUBY_VERSION < '2.6.0'
-                     s(:defn, :foo,
-                       s(:args, :"**bar"),
-                       s(:iter,
-                         s(:call, nil, :baz),
-                         s(:args, :"**qux"),
-                         s(:block,
-                           s(:lvar, :bar),
-                           s(:call, nil, :qux))))
-                   else
-                     s(:defn, :foo,
-                       s(:args, :"**bar"),
-                       s(:iter,
-                         s(:call, nil, :baz),
-                         s(:args, :"**qux"),
-                         s(:block,
-                           s(:lvar, :bar),
-                           s(:lvar, :qux))))
-                   end
+      it 'treats block kwargs as lvars' do
         'def foo(**bar); baz { |**qux| bar; qux }; end'.
-          must_be_parsed_as expected
+          must_be_parsed_as s(:defn, :foo,
+                              s(:args, :"**bar"),
+                              s(:iter,
+                                s(:call, nil, :baz),
+                                s(:args, :"**qux"),
+                                s(:block,
+                                  s(:lvar, :bar),
+                                  s(:lvar, :qux))))
       end
 
       it 'works with a method argument with a default value' do

--- a/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
@@ -373,5 +373,20 @@ describe RipperRubyParser::Parser do
                                 s(:call, nil, :bar)))
       end
     end
+
+    describe 'when extra compatibility is turned on' do
+      it 'treats block kwargs as calls' do
+        'def foo(**bar); baz { |**qux| bar; qux }; end'.
+          must_be_parsed_as s(:defn, :foo,
+                              s(:args, :"**bar"),
+                              s(:iter,
+                                s(:call, nil, :baz),
+                                s(:args, :"**qux"),
+                                s(:block,
+                                  s(:lvar, :bar),
+                                  s(:call, nil, :qux)))),
+                            extra_compatible: true
+      end
+    end
   end
 end


### PR DESCRIPTION
* Handle rest kwargs correctly for blocks
* Emulate RubyParser 3.12's behavior in extra-compatible mode
* Update set of supported Rubies.