### PR TITLE
Update ruby parser compatibility to 3.13.0

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/assignment.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/assignment.rb
@@ -6,11 +6,6 @@ module RipperRubyParser
     module Assignment
       def process_assign(exp)
         _, lvalue, value = exp.shift 3
-        if extra_compatible && value.sexp_type == :rescue_mod
-          if [:command, :command_call].include? value[1].sexp_type
-            return process s(:rescue_mod, s(:assign, lvalue, value[1]), value[2])
-          end
-        end
 
         lvalue = process(lvalue)
         value = process(value)

--- a/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
@@ -107,6 +107,9 @@ module RipperRubyParser
 
       def process_rescue_mod(exp)
         _, scary, safe = exp.shift 3
+        if extra_compatible && scary.sexp_type == :assign
+          return process s(:assign, scary[1], s(:rescue_mod, scary[2], safe))
+        end
         s(:rescue, process(scary), s(:resbody, s(:array), process(safe)))
       end
 

--- a/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
@@ -10,7 +10,7 @@ module RipperRubyParser
         call = process(call)
         args = process(args)
         kwrest = kwrest_param(args) if args
-        stmt = with_block_kwrest(kwrest) { process(stmt) }
+        stmt = with_kwrest(kwrest) { process(stmt) }
         make_iter call, args, safe_unwrap_void_stmt(stmt)
       end
 

--- a/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
@@ -113,8 +113,7 @@ module RipperRubyParser
       private
 
       def replace_kwrest_arg_call?(method)
-        method_kwrest_arg?(method) ||
-          !extra_compatible && block_kwrest_arg?(method)
+        kwrest_arg?(method)
       end
     end
   end

--- a/lib/ripper_ruby_parser/sexp_handlers/methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/methods.rb
@@ -132,19 +132,8 @@ module RipperRubyParser
         result
       end
 
-      def with_block_kwrest(kwrest)
-        @block_kwrest.push kwrest
-        result = yield
-        @block_kwrest.pop
-        result
-      end
-
-      def method_kwrest_arg?(method)
+      def kwrest_arg?(method)
         @kwrest.include?(method)
-      end
-
-      def block_kwrest_arg?(method)
-        @block_kwrest.include?(method)
       end
     end
   end

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -150,7 +150,7 @@ module RipperRubyParser
     def process_BEGIN(exp)
       _, body = exp.shift 2
       body = reject_void_stmt map_process_list body.sexp_body
-      s(:iter, s(:preexe), s(:args), *body)
+      s(:iter, s(:preexe), 0, *body)
     end
 
     def process_END(exp)

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -200,13 +200,7 @@ module RipperRubyParser
     end
 
     def process_at_ident(exp)
-      with_position_from_node_symbol(exp) do |ident|
-        if replace_kwrest_arg_lvar? ident
-          s(:call, nil, ident)
-        else
-          s(:lvar, ident)
-        end
-      end
+      make_identifier(:lvar, exp)
     end
 
     def process_at_op(exp)
@@ -275,10 +269,6 @@ module RipperRubyParser
     def make_literal(exp)
       _, val, pos = exp.shift 3
       with_position(pos, s(:lit, yield(val)))
-    end
-
-    def replace_kwrest_arg_lvar?(ident)
-      extra_compatible && @block_kwrest.include?(ident)
     end
   end
 end

--- a/ripper_ruby_parser.gemspec
+++ b/ripper_ruby_parser.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('minitest', ['~> 5.2'])
   s.add_development_dependency('rake', ['~> 12.0'])
-  s.add_development_dependency('ruby_parser', ['~> 3.12.0'])
+  s.add_development_dependency('ruby_parser', ['~> 3.13.0'])
   s.add_development_dependency('simplecov')
 
   s.require_paths = ['lib']

--- a/test/ripper_ruby_parser/parser_test.rb
+++ b/test/ripper_ruby_parser/parser_test.rb
@@ -148,12 +148,12 @@ describe RipperRubyParser::Parser do
     describe 'for the BEGIN keyword' do
       it 'converts to a :preexe iterator' do
         'BEGIN { foo }'.
-          must_be_parsed_as s(:iter, s(:preexe), s(:args), s(:call, nil, :foo))
+          must_be_parsed_as s(:iter, s(:preexe), 0, s(:call, nil, :foo))
       end
 
       it 'works with an empty block' do
         'BEGIN { }'.
-          must_be_parsed_as s(:iter, s(:preexe), s(:args))
+          must_be_parsed_as s(:iter, s(:preexe), 0)
       end
     end
 

--- a/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
@@ -210,6 +210,73 @@ describe RipperRubyParser::Parser do
           'foo = Bar.baz qux rescue quuz'.
             must_be_parsed_as expected
         end
+
+        it 'works with a method call with argument without brackets' do
+          expected = if RUBY_VERSION < '2.4.0'
+                       s(:rescue,
+                         s(:lasgn, :foo, s(:call, nil, :bar, s(:call, nil, :baz))),
+                         s(:resbody, s(:array), s(:call, nil, :qux)))
+                     else
+                       s(:lasgn, :foo,
+                         s(:rescue,
+                           s(:call, nil, :bar, s(:call, nil, :baz)),
+                           s(:resbody, s(:array), s(:call, nil, :qux))))
+                     end
+          'foo = bar baz rescue qux'.must_be_parsed_as expected
+        end
+
+        it 'works with a class method call with argument without brackets' do
+          expected = if RUBY_VERSION < '2.4.0'
+                       s(:rescue,
+                         s(:lasgn, :foo, s(:call, s(:const, :Bar), :baz, s(:call, nil, :qux))),
+                         s(:resbody, s(:array), s(:call, nil, :quuz)))
+                     else
+                       s(:lasgn, :foo,
+                         s(:rescue,
+                           s(:call, s(:const, :Bar), :baz, s(:call, nil, :qux)),
+                           s(:resbody, s(:array), s(:call, nil, :quuz))))
+                     end
+          'foo = Bar.baz qux rescue quuz'.
+            must_be_parsed_as expected
+        end
+      end
+
+      describe 'with a rescue modifier in extra compatible mode' do
+        it 'works with assigning a bare method call' do
+          'foo = bar rescue baz'.
+            must_be_parsed_as s(:lasgn, :foo,
+                                s(:rescue,
+                                  s(:call, nil, :bar),
+                                  s(:resbody, s(:array), s(:call, nil, :baz)))),
+                              extra_compatible: true
+        end
+
+        it 'works with a method call with argument' do
+          'foo = bar(baz) rescue qux'.
+            must_be_parsed_as s(:lasgn, :foo,
+                                s(:rescue,
+                                  s(:call, nil, :bar, s(:call, nil, :baz)),
+                                  s(:resbody, s(:array), s(:call, nil, :qux)))),
+                              extra_compatible: true
+        end
+
+        it 'always uses post-2.3 behavior for a method call with bare argument' do
+          'foo = bar baz rescue qux'.
+            must_be_parsed_as s(:lasgn, :foo,
+                                s(:rescue,
+                                  s(:call, nil, :bar, s(:call, nil, :baz)),
+                                  s(:resbody, s(:array), s(:call, nil, :qux)))),
+                              extra_compatible: true
+        end
+
+        it 'always uses post-2.3 behavior for a class method call with bare argument' do
+          'foo = Bar.baz qux rescue quuz'.
+            must_be_parsed_as s(:lasgn, :foo,
+                                s(:rescue,
+                                  s(:call, s(:const, :Bar), :baz, s(:call, nil, :qux)),
+                                  s(:resbody, s(:array), s(:call, nil, :quuz)))),
+                              extra_compatible: true
+        end
       end
 
       it 'sets the correct line numbers' do

--- a/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
@@ -520,55 +520,5 @@ describe RipperRubyParser::Parser do
         end
       end
     end
-
-    describe 'when extra compatibility is turned on' do
-      it 'works with a bare method call' do
-        'foo = bar'.
-          must_be_parsed_as s(:lasgn, :foo, s(:call, nil, :bar)),
-                            extra_compatible: true
-      end
-
-      it 'works with a literal' do
-        'foo = 0'.
-          must_be_parsed_as s(:lasgn, :foo, s(:lit, 0)),
-                            extra_compatible: true
-      end
-
-      it 'works with a bare method call with rescue modifier' do
-        'foo = bar rescue baz'.
-          must_be_parsed_as s(:lasgn, :foo,
-                              s(:rescue,
-                                s(:call, nil, :bar),
-                                s(:resbody, s(:array), s(:call, nil, :baz)))),
-                            extra_compatible: true
-      end
-
-      it 'works with a method call with argument with bracket with rescue modifier' do
-        'foo = bar(baz) rescue qux'.
-          must_be_parsed_as s(:lasgn, :foo,
-                              s(:rescue,
-                                s(:call, nil, :bar, s(:call, nil, :baz)),
-                                s(:resbody, s(:array), s(:call, nil, :qux)))),
-                            extra_compatible: true
-      end
-
-      it 'works with a method call with argument without bracket with rescue modifier' do
-        'foo = bar baz rescue qux'.
-          must_be_parsed_as s(:rescue,
-                              s(:lasgn, :foo, s(:call, nil, :bar, s(:call, nil, :baz))),
-                              s(:resbody, s(:array), s(:call, nil, :qux))),
-                            extra_compatible: true
-      end
-
-      it 'works with a class method call with argument without bracket with rescue modifier' do
-        'foo = Bar.baz qux rescue quuz'.
-          must_be_parsed_as s(:rescue,
-                              s(:lasgn,
-                                :foo,
-                                s(:call, s(:const, :Bar), :baz, s(:call, nil, :qux))),
-                              s(:resbody, s(:array), s(:call, nil, :quuz))),
-                            extra_compatible: true
-      end
-    end
   end
 end

--- a/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
@@ -389,7 +389,7 @@ describe RipperRubyParser::Parser do
     end
 
     describe 'when extra compatibility is turned on' do
-      it 'treats block kwargs as calls' do
+      it 'still treats block kwargs as lvars' do
         'def foo(**bar); baz { |**qux| bar; qux }; end'.
           must_be_parsed_as s(:defn, :foo,
                               s(:args, :"**bar"),
@@ -398,7 +398,7 @@ describe RipperRubyParser::Parser do
                                 s(:args, :"**qux"),
                                 s(:block,
                                   s(:lvar, :bar),
-                                  s(:call, nil, :qux)))),
+                                  s(:lvar, :qux)))),
                             extra_compatible: true
       end
     end


### PR DESCRIPTION
* Update handling of BEGIN blocks to match RubyParser 3.13.0
* In extra-compatible mode, always handle rescue modifiers the way Ruby 2.4+ handles them, even when running on Ruby 2.3.
* Always treat block rest keyword arguments as local variables.