### PR TITLE
Improve compatibility of handling escaped line-endings

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/literals.rb
@@ -190,12 +190,7 @@ module RipperRubyParser
 
       def alternative_process_at_tstring_content(exp)
         _, content, _, delim = exp.shift 4
-        string = case delim
-                 when *INTERPOLATING_STRINGS
-                   unescape(content)
-                 else
-                   content
-                 end
+        string = handle_string_unescaping(content, delim)
         string.force_encoding('ascii-8bit') if string == "\0"
         s(:str, string)
       end

--- a/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
@@ -666,6 +666,28 @@ describe RipperRubyParser::Parser do
                                 (+"2\xC2\xBD\n").force_encoding('ascii-8bit')),
                               extra_compatible: true
         end
+
+        it 'handles interpolation' do
+          "<<FOO\n\#{bar}\nFOO".
+            must_be_parsed_as s(:dstr, '',
+                                s(:evstr, s(:call, nil, :bar)),
+                                s(:str, "\n"))
+        end
+
+        it 'handles line continuation after interpolation' do
+          "<<FOO\n\#{bar}\nbaz\\\nqux\nFOO".
+            must_be_parsed_as s(:dstr, '',
+                                s(:evstr, s(:call, nil, :bar)),
+                                s(:str, "\nbazqux\n"))
+        end
+
+        it 'handles line continuation after interpolation in extra-compatible mode' do
+          "<<FOO\n\#{bar}\nbaz\\\nqux\nFOO".
+            must_be_parsed_as s(:dstr, '',
+                                s(:evstr, s(:call, nil, :bar)),
+                                s(:str, "\nbazqux\n")),
+                              extra_compatible: true
+        end
       end
     end
 

--- a/test/samples/strings.rb
+++ b/test/samples/strings.rb
@@ -57,6 +57,12 @@ foo4\
 bar
 EOS
 
+<<EOS
+#{bar}
+baz \
+qux
+EOS
+
 %Q[foo5\
 bar]
 


### PR DESCRIPTION
This fixes the case where a line ending is escaped in a heredoc with some interpolations occurring earlier in the heredoc.