### PR TITLE
Improve compatibility of operator assignment

### DIFF
--- a/test/samples/assignment.rb
+++ b/test/samples/assignment.rb
@@ -1,0 +1,7 @@
+# Samples of assignment
+foo[bar] = baz
+foo[bar] += baz
+foo[bar] ||= foo bar
+foo[bar] ||= foo(bar)
+foo[bar] ||= baz.qux quuz
+foo[bar] ||= baz.qux(quuz)


### PR DESCRIPTION
Handles the exceptional case of operator assignment to a collection element, where the value is a method or function call with a parameter without parentheses.