### PR TITLE
Handle backtick as a symbol

### DIFF
--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -29,6 +29,7 @@ module RipperRubyParser
 
     def on_backtick(delimiter)
       @delimiter_stack.push delimiter
+      super
     end
 
     def on_comment(tok)

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -31,6 +31,8 @@ module RipperRubyParser
       @processors[:@kw] = :process_at_kw
       @processors[:@op] = :process_at_op
       @processors[:@backref] = :process_at_backref
+
+      @processors[:@backtick] = :process_at_backtick
       @processors[:@period] = :process_at_period
 
       @processors[:@tstring_content] = :process_at_tstring_content
@@ -205,6 +207,10 @@ module RipperRubyParser
 
     def process_at_op(exp)
       make_identifier(:op, exp)
+    end
+
+    def process_at_backtick(exp)
+      make_identifier(:backtick, exp)
     end
 
     def process_at_kw(exp)

--- a/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
@@ -972,6 +972,10 @@ describe RipperRubyParser::Parser do
           must_be_parsed_as s(:lit, :__FILE__)
       end
 
+      it 'works for a backtick symbol' do
+        ':`'.must_be_parsed_as s(:lit, :`)
+      end
+
       it 'works for simple dsyms' do
         ':"foo"'.
           must_be_parsed_as s(:lit, :foo)

--- a/test/samples/misc.rb
+++ b/test/samples/misc.rb
@@ -237,3 +237,6 @@ class Foo
   def self.foo((bar, (baz, *qux)))
   end
 end
+
+# Special symbols
+[:`, :|, :*, :&, :%, :'^', :-@, :+@, :'~@']


### PR DESCRIPTION
Tests and fixes parsing of:

```ruby
 :`
```