### PR TITLE
Bump compatibility version to 3.13.1

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/literals.rb
@@ -167,7 +167,7 @@ module RipperRubyParser
         return '', [] if list.empty?
 
         list = merge_raw_string_literals list
-        list = map_process_string_parts list
+        list = map_process_list list
 
         parts = list.flat_map do |item|
           type, val, *rest = item
@@ -202,25 +202,6 @@ module RipperRubyParser
             items
           end
         end
-      end
-
-      def map_process_string_parts(list)
-        parts = [process(list.shift)]
-        parts += list.map do |item|
-          if extra_compatible && item.sexp_type == :@tstring_content
-            alternative_process_at_tstring_content(item)
-          else
-            process(item)
-          end
-        end
-        parts
-      end
-
-      def alternative_process_at_tstring_content(exp)
-        _, content, _, delim = exp.shift 4
-        string = handle_string_unescaping(content, delim)
-        string.force_encoding('ascii-8bit') if string == "\0"
-        s(:str, string)
       end
 
       def character_flags_to_numerical(flags)

--- a/lib/ripper_ruby_parser/sexp_handlers/literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/literals.rb
@@ -272,13 +272,7 @@ module RipperRubyParser
 
       def handle_string_encoding(string, delim)
         case delim
-        when INTERPOLATING_HEREDOC, INTERPOLATING_WORD_LIST
-          if extra_compatible
-            string
-          else
-            fix_encoding string
-          end
-        when *INTERPOLATING_STRINGS
+        when INTERPOLATING_HEREDOC, INTERPOLATING_WORD_LIST, *INTERPOLATING_STRINGS
           fix_encoding string
         else
           string

--- a/lib/ripper_ruby_parser/unescape.rb
+++ b/lib/ripper_ruby_parser/unescape.rb
@@ -106,8 +106,7 @@ module RipperRubyParser
       when /^u\{/
         hex_to_unicode_char(bare[2..-2])
       when /^u/
-        hex_to_unicode_char(bare[1..4]) +
-          (extra_compatible ? '' : bare[5..-1])
+        hex_to_unicode_char(bare[1..4]) + bare[5..-1]
       when /^(c|C-).$/
         control(bare[-1].ord).chr
       when /^M-.$/

--- a/ripper_ruby_parser.gemspec
+++ b/ripper_ruby_parser.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('minitest', ['~> 5.2'])
   s.add_development_dependency('rake', ['~> 12.0'])
-  s.add_development_dependency('ruby_parser', ['~> 3.13.0'])
+  s.add_development_dependency('ruby_parser', ['~> 3.13.1'])
   s.add_development_dependency('simplecov')
 
   s.require_paths = ['lib']

--- a/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
@@ -269,7 +269,7 @@ describe RipperRubyParser::Parser do
 
         it 'works with unicode escapes in extra-compatible mode' do
           '"foo\\u273bbar"'.
-            must_be_parsed_as s(:str, 'foo✻r'), extra_compatible: true
+            must_be_parsed_as s(:str, 'foo✻bar'), extra_compatible: true
         end
 
         it 'works with unicode escapes with braces' do

--- a/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
@@ -436,21 +436,21 @@ describe RipperRubyParser::Parser do
       end
 
       describe 'with interpolations and escape sequences in extra-compatible mode' do
-        it 'does not convert to unicode after interpolation' do
+        it 'converts to unicode after interpolation' do
           '"#{foo}2\302\275"'.
             must_be_parsed_as s(:dstr,
                                 '',
                                 s(:evstr, s(:call, nil, :foo)),
-                                s(:str, (+"2\xC2\xBD").force_encoding('ascii-8bit'))),
+                                s(:str, '2½')),
                               extra_compatible: true
         end
 
-        it 'keeps single null byte as ascii after interpolation' do
+        it 'converts single null byte to unicode after interpolation' do
           '"#{foo}\0"'.
             must_be_parsed_as s(:dstr,
                                 '',
                                 s(:evstr, s(:call, nil, :foo)),
-                                s(:str, (+"\x00").force_encoding('ascii-8bit'))),
+                                s(:str, "\u0000")),
                               extra_compatible: true
         end
 

--- a/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
@@ -691,11 +691,9 @@ describe RipperRubyParser::Parser do
             must_be_parsed_as s(:str, "2½\n")
         end
 
-        it 'does not convert to unicode in extra-compatible mode' do
+        it 'converts to unicode in extra-compatible mode' do
           "<<FOO\n2\\302\\275\nFOO".
-            must_be_parsed_as s(:str,
-                                (+"2\xC2\xBD\n").force_encoding('ascii-8bit')),
-                              extra_compatible: true
+            must_be_parsed_as s(:str, "2½\n"), extra_compatible: true
         end
 
         it 'handles interpolation' do
@@ -799,11 +797,9 @@ describe RipperRubyParser::Parser do
         '%W(2\302\275)'.must_be_parsed_as s(:array, s(:str, '2½'))
       end
 
-      it 'does not convert to unicode if possible in extra-compatible mode' do
+      it 'converts to unicode if possible in extra-compatible mode' do
         '%W(2\302\275)'.
-          must_be_parsed_as s(:array,
-                              s(:str, (+"2\xC2\xBD").force_encoding('ascii-8bit'))),
-                            extra_compatible: true
+          must_be_parsed_as s(:array, s(:str, '2½')), extra_compatible: true
       end
 
       it 'correctly handles line continuation' do

--- a/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
@@ -78,15 +78,6 @@ describe RipperRubyParser::Parser do
                                 s(:str, 'baz'))
         end
 
-        it 'works for a simple interpolation in extra-compatible mode' do
-          '/foo#{bar}baz/'.
-            must_be_parsed_as s(:dregx,
-                                'foo',
-                                s(:evstr, s(:call, nil, :bar)),
-                                s(:str, 'baz')),
-                              extra_compatible: true
-        end
-
         it 'works for a regex literal with flags and interpolation' do
           '/foo#{bar}/ixm'.
             must_be_parsed_as s(:dregx,
@@ -267,21 +258,12 @@ describe RipperRubyParser::Parser do
           '"foo\\u273bbar"'.must_be_parsed_as s(:str, 'foo✻bar')
         end
 
-        it 'works with unicode escapes in extra-compatible mode' do
-          '"foo\\u273bbar"'.
-            must_be_parsed_as s(:str, 'foo✻bar'), extra_compatible: true
-        end
-
         it 'works with unicode escapes with braces' do
           '"foo\\u{273b}bar"'.must_be_parsed_as s(:str, 'foo✻bar')
         end
 
         it 'converts to unicode if possible' do
           '"2\302\275"'.must_be_parsed_as s(:str, '2½')
-        end
-
-        it 'converts to unicode if possible in extra-compatible mode' do
-          '"2\302\275"'.must_be_parsed_as s(:str, '2½'), extra_compatible: true
         end
 
         it 'does not convert to unicode if result is not valid' do
@@ -433,34 +415,13 @@ describe RipperRubyParser::Parser do
                                 s(:evstr, s(:call, nil, :foo)),
                                 s(:str, "\u0000"))
         end
-      end
-
-      describe 'with interpolations and escape sequences in extra-compatible mode' do
-        it 'converts to unicode after interpolation' do
-          '"#{foo}2\302\275"'.
-            must_be_parsed_as s(:dstr,
-                                '',
-                                s(:evstr, s(:call, nil, :foo)),
-                                s(:str, '2½')),
-                              extra_compatible: true
-        end
-
-        it 'converts single null byte to unicode after interpolation' do
-          '"#{foo}\0"'.
-            must_be_parsed_as s(:dstr,
-                                '',
-                                s(:evstr, s(:call, nil, :foo)),
-                                s(:str, "\u0000")),
-                              extra_compatible: true
-        end
 
         it 'converts string with null to unicode after interpolation' do
           '"#{foo}bar\0"'.
             must_be_parsed_as s(:dstr,
                                 '',
                                 s(:evstr, s(:call, nil, :foo)),
-                                s(:str, "bar\x00")),
-                              extra_compatible: true
+                                s(:str, "bar\x00"))
         end
       end
 
@@ -488,12 +449,6 @@ describe RipperRubyParser::Parser do
         it 'does not process line continuation' do
           "'foo\\\nbar'".
             must_be_parsed_as s(:str, "foo\\\nbar")
-        end
-
-        it 'handles escape sequences correctly in extra-compatible mode' do
-          "'foo\\'bar\\\nbaz\\aqux'".
-            must_be_parsed_as s(:str, "foo'bar\\\nbaz\\aqux"),
-                              extra_compatible: true
         end
       end
 
@@ -644,21 +599,9 @@ describe RipperRubyParser::Parser do
             must_be_parsed_as s(:str, "bar\tbaz\n")
         end
 
-        it 'works for escape sequences in extra-compatible mode' do
-          "<<FOO\nbar\\tbaz\nFOO".
-            must_be_parsed_as s(:str, "bar\tbaz\n"),
-                              extra_compatible: true
-        end
-
         it 'does not unescape with single quoted version' do
           "<<'FOO'\nbar\\tbaz\nFOO".
             must_be_parsed_as s(:str, "bar\\tbaz\n")
-        end
-
-        it 'does not unescape with single quoted version in extra-compatible mode' do
-          "<<'FOO'\nbar\\tbaz\nFOO".
-            must_be_parsed_as s(:str, "bar\\tbaz\n"),
-                              extra_compatible: true
         end
 
         it 'works with multiple lines with the single quoted version' do
@@ -691,11 +634,6 @@ describe RipperRubyParser::Parser do
             must_be_parsed_as s(:str, "2½\n")
         end
 
-        it 'converts to unicode in extra-compatible mode' do
-          "<<FOO\n2\\302\\275\nFOO".
-            must_be_parsed_as s(:str, "2½\n"), extra_compatible: true
-        end
-
         it 'handles interpolation' do
           "<<FOO\n\#{bar}\nFOO".
             must_be_parsed_as s(:dstr, '',
@@ -708,14 +646,6 @@ describe RipperRubyParser::Parser do
             must_be_parsed_as s(:dstr, '',
                                 s(:evstr, s(:call, nil, :bar)),
                                 s(:str, "\nbazqux\n"))
-        end
-
-        it 'handles line continuation after interpolation in extra-compatible mode' do
-          "<<FOO\n\#{bar}\nbaz\\\nqux\nFOO".
-            must_be_parsed_as s(:dstr, '',
-                                s(:evstr, s(:call, nil, :bar)),
-                                s(:str, "\nbazqux\n")),
-                              extra_compatible: true
         end
 
         it 'handles line continuation after interpolation for the indentable case' do
@@ -797,11 +727,6 @@ describe RipperRubyParser::Parser do
         '%W(2\302\275)'.must_be_parsed_as s(:array, s(:str, '2½'))
       end
 
-      it 'converts to unicode if possible in extra-compatible mode' do
-        '%W(2\302\275)'.
-          must_be_parsed_as s(:array, s(:str, '2½')), extra_compatible: true
-      end
-
       it 'correctly handles line continuation' do
         "%W(foo\\\nbar baz)".
           must_be_parsed_as s(:array,
@@ -815,20 +740,6 @@ describe RipperRubyParser::Parser do
                               s(:str, 'foo'),
                               s(:str, 'bar'),
                               s(:str, 'baz'))
-      end
-
-      it 'handles escaped spaces in extra-compatible mode' do
-        '%W(foo bar\ baz)'.
-          must_be_parsed_as s(:array, s(:str, 'foo'), s(:str, 'bar baz')),
-                            extra_compatible: true
-      end
-
-      it 'correctly handles line continuation in extra-compatible mode' do
-        "%W(foo\\\nbar baz)".
-          must_be_parsed_as s(:array,
-                              s(:str, "foo\nbar"),
-                              s(:str, 'baz')),
-                            extra_compatible: true
       end
     end
 


### PR DESCRIPTION
This removes all extra-compatible handling of string literals.