### PR TITLE
Handle directly nested parentheses in destructuring

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/assignment.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/assignment.rb
@@ -78,7 +78,11 @@ module RipperRubyParser
       def process_mlhs_paren(exp)
         _, contents = exp.shift 2
 
-        process(contents)
+        if contents.sexp_type == :mlhs_paren
+          s(:masgn, s(:array, process(contents)))
+        else
+          process(contents)
+        end
       end
 
       def process_mlhs(exp)

--- a/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
@@ -388,6 +388,17 @@ describe RipperRubyParser::Parser do
                                     s(:call, nil, :quuz)))))
       end
 
+      it 'works with destructuring with multiple levels' do
+        '((foo, bar)) = baz'.
+          must_be_parsed_as s(:masgn,
+                              s(:array,
+                                s(:masgn,
+                                  s(:array,
+                                    s(:lasgn, :foo),
+                                    s(:lasgn, :bar)))),
+                              s(:to_ary, s(:call, nil, :baz)))
+      end
+
       it 'works with instance variables' do
         '@foo, @bar = baz'.
           must_be_parsed_as s(:masgn,

--- a/test/samples/assignment.rb
+++ b/test/samples/assignment.rb
@@ -5,3 +5,13 @@ foo[bar] ||= foo bar
 foo[bar] ||= foo(bar)
 foo[bar] ||= baz.qux quuz
 foo[bar] ||= baz.qux(quuz)
+
+# Destructuring assignments
+foo, bar = baz
+(foo, bar) = baz
+((foo, bar)) = baz
+(((foo, bar))) = baz
+foo, (bar, baz) = qux
+foo, ((bar, baz)) = qux
+foo, (((bar, baz))) = qux
+foo, (bar, (baz, qux)) = quuz


### PR DESCRIPTION
This fixes the handling of cases like:

```ruby
((foo, bar)) = baz
```

These need an extra level of `s(:masgn, s(:array ...))` to reflect the semantic difference with the cases:

```ruby
foo, bar = baz
(foo, bar) = baz
```