### PR TITLE
Compare with RubyParser for current Ruby

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
@@ -107,9 +107,6 @@ module RipperRubyParser
 
       def process_rescue_mod(exp)
         _, scary, safe = exp.shift 3
-        if extra_compatible && scary.sexp_type == :assign
-          return process s(:assign, scary[1], s(:rescue_mod, scary[2], safe))
-        end
 
         s(:rescue, process(scary), s(:resbody, s(:array), process(safe)))
       end

--- a/test/end_to_end/comments_test.rb
+++ b/test/end_to_end/comments_test.rb
@@ -9,7 +9,7 @@ describe 'Using RipperRubyParser and RubyParser' do
   end
 
   let :oldparser do
-    RubyParser.new
+    RubyParser.for_current_ruby
   end
 
   describe 'for a program with quite some comments' do

--- a/test/end_to_end/lib_comparison_test.rb
+++ b/test/end_to_end/lib_comparison_test.rb
@@ -9,7 +9,7 @@ describe 'Using RipperRubyParser and RubyParser' do
   end
 
   let :oldparser do
-    RubyParser.new
+    RubyParser.for_current_ruby
   end
 
   Dir.glob('lib/**/*.rb').each do |file|

--- a/test/end_to_end/line_numbering_test.rb
+++ b/test/end_to_end/line_numbering_test.rb
@@ -25,7 +25,7 @@ describe 'Using RipperRubyParser and RubyParser' do
   end
 
   let :oldparser do
-    RubyParser.new
+    RubyParser.for_current_ruby
   end
 
   describe 'for a multi-line program' do

--- a/test/end_to_end/test_comparison_test.rb
+++ b/test/end_to_end/test_comparison_test.rb
@@ -9,7 +9,7 @@ describe 'Using RipperRubyParser and RubyParser' do
   end
 
   let :oldparser do
-    RubyParser.new
+    RubyParser.for_current_ruby
   end
 
   Dir.glob('test/ripper_ruby_parser/**/*.rb').each do |file|

--- a/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
@@ -241,44 +241,6 @@ describe RipperRubyParser::Parser do
         end
       end
 
-      describe 'with a rescue modifier in extra compatible mode' do
-        it 'works with assigning a bare method call' do
-          'foo = bar rescue baz'.
-            must_be_parsed_as s(:lasgn, :foo,
-                                s(:rescue,
-                                  s(:call, nil, :bar),
-                                  s(:resbody, s(:array), s(:call, nil, :baz)))),
-                              extra_compatible: true
-        end
-
-        it 'works with a method call with argument' do
-          'foo = bar(baz) rescue qux'.
-            must_be_parsed_as s(:lasgn, :foo,
-                                s(:rescue,
-                                  s(:call, nil, :bar, s(:call, nil, :baz)),
-                                  s(:resbody, s(:array), s(:call, nil, :qux)))),
-                              extra_compatible: true
-        end
-
-        it 'always uses post-2.3 behavior for a method call with bare argument' do
-          'foo = bar baz rescue qux'.
-            must_be_parsed_as s(:lasgn, :foo,
-                                s(:rescue,
-                                  s(:call, nil, :bar, s(:call, nil, :baz)),
-                                  s(:resbody, s(:array), s(:call, nil, :qux)))),
-                              extra_compatible: true
-        end
-
-        it 'always uses post-2.3 behavior for a class method call with bare argument' do
-          'foo = Bar.baz qux rescue quuz'.
-            must_be_parsed_as s(:lasgn, :foo,
-                                s(:rescue,
-                                  s(:call, s(:const, :Bar), :baz, s(:call, nil, :qux)),
-                                  s(:resbody, s(:array), s(:call, nil, :quuz)))),
-                              extra_compatible: true
-        end
-      end
-
       it 'sets the correct line numbers' do
         result = parser.parse 'foo = {}'
         result.line.must_equal 1

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -61,7 +61,7 @@ module MiniTest
     end
 
     def assert_parsed_as_before(code)
-      oldparser = RubyParser.new
+      oldparser = RubyParser.for_current_ruby
       newparser = RipperRubyParser::Parser.new
       newparser.extra_compatible = true
       expected = oldparser.parse code.dup


### PR DESCRIPTION
The intent has always been for RipperRubyParser to produce results compatible with the RubyParser version matching the currently running version of Ruby. This adjusts the end-to-end tests to test exactly that.

Because of this change, the extra-compatible handling of the `rescue` modifier can be removed.