### PR TITLE
Improve compatibility parsing carriage returns in heredocs

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/literals.rb
@@ -256,7 +256,11 @@ module RipperRubyParser
       def handle_string_unescaping(content, delim)
         case delim
         when INTERPOLATING_HEREDOC, *INTERPOLATING_STRINGS
-          unescape(content)
+          if extra_compatible
+            unescape(content).delete("\r")
+          else
+            unescape(content)
+          end
         when INTERPOLATING_WORD_LIST
           unescape_wordlist_word(content)
         when *NON_INTERPOLATING_STRINGS

--- a/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
@@ -599,6 +599,16 @@ describe RipperRubyParser::Parser do
             must_be_parsed_as s(:str, "bar\tbaz\n")
         end
 
+        it 'converts \r to carriage returns' do
+          "<<FOO\nbar\\rbaz\\r\nFOO".
+            must_be_parsed_as s(:str, "bar\rbaz\r\n")
+        end
+
+        it 'removes \r in extra-compatible mode' do
+          "<<FOO\nbar\\rbaz\\r\nFOO".
+            must_be_parsed_as s(:str, "barbaz\n"), extra_compatible: true
+        end
+
         it 'does not unescape with single quoted version' do
           "<<'FOO'\nbar\\tbaz\nFOO".
             must_be_parsed_as s(:str, "bar\\tbaz\n")

--- a/test/samples/strings.rb
+++ b/test/samples/strings.rb
@@ -37,6 +37,16 @@ FOO
 \n
 FOO
 
+# Escape sequences in heredocs, in particular carriage returns
+#
+<<FOO
+foo\rbar\tbaz\r
+FOO
+
+<<'FOO'
+foo\rbar\tbaz\r
+FOO
+
 # Line continuation
 "foo\
 bar"


### PR DESCRIPTION
RubyParser basically throws out all carriage returns, so do that when running in extra-compatible mode.