### PR TITLE
Restore handling of carriage returns for double-quoted strings

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/literals.rb
@@ -255,12 +255,14 @@ module RipperRubyParser
 
       def handle_string_unescaping(content, delim)
         case delim
-        when INTERPOLATING_HEREDOC, *INTERPOLATING_STRINGS
+        when INTERPOLATING_HEREDOC
           if extra_compatible
             unescape(content).delete("\r")
           else
             unescape(content)
           end
+        when *INTERPOLATING_STRINGS
+          unescape(content)
         when INTERPOLATING_WORD_LIST
           unescape_wordlist_word(content)
         when *NON_INTERPOLATING_STRINGS

--- a/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
@@ -604,11 +604,6 @@ describe RipperRubyParser::Parser do
             must_be_parsed_as s(:str, "bar\rbaz\r\n")
         end
 
-        it 'removes \r in extra-compatible mode' do
-          "<<FOO\nbar\\rbaz\\r\nFOO".
-            must_be_parsed_as s(:str, "barbaz\n"), extra_compatible: true
-        end
-
         it 'does not unescape with single quoted version' do
           "<<'FOO'\nbar\\tbaz\nFOO".
             must_be_parsed_as s(:str, "bar\\tbaz\n")
@@ -1105,6 +1100,17 @@ describe RipperRubyParser::Parser do
       it 'works for rationals' do
         '1000r'.
           must_be_parsed_as s(:lit, 1000r)
+      end
+    end
+
+    describe 'in extra compatible mode' do
+      it 'converts \r to carriage returns in double-quoted strings' do
+        '"foo\\rbar"'.must_be_parsed_as s(:str, "foo\rbar"), extra_compatible: true
+      end
+
+      it 'removes \r from heredocs' do
+        "<<FOO\nbar\\rbaz\\r\nFOO".
+          must_be_parsed_as s(:str, "barbaz\n"), extra_compatible: true
       end
     end
   end

--- a/test/samples/strings.rb
+++ b/test/samples/strings.rb
@@ -6,6 +6,7 @@
 %w(foo\nbar baz)
 
 "foo\u273bbar"
+"foo\a\b\e\f\r\s\t\vbar\nbaz"
 "\0"
 "foo#{bar}\0"
 "foo#{bar}baz\0"
@@ -13,6 +14,7 @@
 "#{foo}2\302\275"
 %W(2\302\275)
 /2\302\275/
+
 
 # Encoding
 "日本語"


### PR DESCRIPTION
Handling carriage-returns in double-quoted strings was broken in commit 5efd19d2e95ed20923b7433c03ca1ae4bda4dfb7. This pull request adds integration tests and fixes the problem.