### PR TITLE
Improve line number comparison testing

### DIFF
--- a/test/end_to_end/comparison_test.rb
+++ b/test/end_to_end/comparison_test.rb
@@ -9,8 +9,8 @@ describe 'Using RipperRubyParser and RubyParser' do
       "puts 'Hello World'"
     end
 
-    it 'gives the same result' do
-      program.must_be_parsed_as_before
+    it 'gives the same result with line numbers' do
+      program.must_be_parsed_as_before with_line_numbers: true
     end
   end
 
@@ -35,8 +35,8 @@ describe 'Using RipperRubyParser and RubyParser' do
       END
     end
 
-    it 'gives the same result' do
-      program.must_be_parsed_as_before
+    it 'gives the same result with line numbers' do
+      program.must_be_parsed_as_before with_line_numbers: true
     end
   end
 
@@ -45,8 +45,8 @@ describe 'Using RipperRubyParser and RubyParser' do
       'def fred() yield(3) if block_given?; end'
     end
 
-    it 'gives the same result' do
-      program.must_be_parsed_as_before
+    it 'gives the same result with line numbers' do
+      program.must_be_parsed_as_before with_line_numbers: true
     end
   end
 
@@ -97,8 +97,8 @@ describe 'Using RipperRubyParser and RubyParser' do
       "/(\#{@types})\\s*(\\w+)\\s*\\(([^)]*)\\)/"
     end
 
-    it 'gives the same result' do
-      program.must_be_parsed_as_before
+    it 'gives the same result with line numbers' do
+      program.must_be_parsed_as_before with_line_numbers: true
     end
   end
 end

--- a/test/end_to_end/line_numbering_test.rb
+++ b/test/end_to_end/line_numbering_test.rb
@@ -4,30 +4,6 @@ require File.expand_path('../test_helper.rb', File.dirname(__FILE__))
 require 'ruby_parser'
 
 describe 'Using RipperRubyParser and RubyParser' do
-  def to_line_numbers(exp)
-    exp.map! do |sub_exp|
-      if sub_exp.is_a? Sexp
-        to_line_numbers sub_exp
-      else
-        sub_exp
-      end
-    end
-
-    if exp.sexp_type == :scope
-      exp
-    else
-      s(:line_number, exp.line, exp)
-    end
-  end
-
-  let :newparser do
-    RipperRubyParser::Parser.new
-  end
-
-  let :oldparser do
-    RubyParser.for_current_ruby
-  end
-
   describe 'for a multi-line program' do
     let :program do
       <<-END
@@ -44,21 +20,12 @@ describe 'Using RipperRubyParser and RubyParser' do
       END
     end
 
-    let :original do
-      oldparser.parse program
-    end
-
-    let :imitation do
-      newparser.parse program
-    end
-
     it 'gives the same result' do
-      imitation.must_equal original
+      program.must_be_parsed_as_before
     end
 
     it 'gives the same result with line numbers' do
-      formatted(to_line_numbers(imitation)).
-        must_equal formatted(to_line_numbers(original))
+      program.must_be_parsed_as_before with_line_numbers: true
     end
   end
 end

--- a/test/ripper_ruby_parser/parser_test.rb
+++ b/test/ripper_ruby_parser/parser_test.rb
@@ -359,11 +359,11 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works for a local variable' do
-        result = parser.parse "foo = bar\nfoo\n"
-        result.sexp_type.must_equal :block
-        result[1].line.must_equal 1
-        result[2].line.must_equal 2
-        result.line.must_equal 1
+        "foo = bar\nfoo\n".
+          must_be_parsed_as s(:block,
+                              s(:lasgn, :foo, s(:call, nil, :bar).line(1)).line(1),
+                              s(:lvar, :foo).line(2)).line(1),
+                            with_line_numbers: true
       end
 
       it 'works for an integer literal' do
@@ -447,15 +447,12 @@ describe RipperRubyParser::Parser do
       end
 
       it 'assigns line numbers to nested sexps without their own line numbers' do
-        result = parser.parse "foo(bar) do\nnext baz\nend\n"
-        result.must_equal s(:iter,
-                            s(:call, nil, :foo, s(:call, nil, :bar)),
-                            0,
-                            s(:next, s(:call, nil, :baz)))
-        arglist = result[1][3]
-        block = result[3]
-        nums = [arglist.line, block.line]
-        nums.must_equal [1, 2]
+        "foo(bar) do\nnext baz\nend\n".
+          must_be_parsed_as s(:iter,
+                              s(:call, nil, :foo, s(:call, nil, :bar).line(1)).line(1),
+                              0,
+                              s(:next, s(:call, nil, :baz).line(2)).line(2)).line(1),
+                            with_line_numbers: true
       end
 
       describe 'when a line number is passed' do


### PR DESCRIPTION
* Set expected line numbers with `Sexp#line`
* Avoid creating wrapping `s(:line ..)` s-expressions for comparing. Use enhanced inspect instead
* Check line numbering in several more end-to-end tests