### PR TITLE
Compatibility updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ source 'https://rubygems.org'
 # The gem's dependencies are specified in the gemspec
 gemspec
 
+# For testing, do not allow sexp_processor 4.12.1: its test cases match an
+# unreleased version of ruby_parser.
+gem 'sexp_processor', ['~> 4.10', '< 4.12.1']
+
 group :local_development do
   gem 'pry'
 end

--- a/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
+++ b/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
@@ -13,6 +13,10 @@ describe RipperRubyParser::CommentingRipperParser do
   end
 
   describe 'handling comments' do
+    # Handle different results for dynamic symbol strings. This was changed in
+    # Ruby 2.6.3 and up. See https://bugs.ruby-lang.org/issues/15670
+    let(:dsym_string_type) { RUBY_VERSION < "2.6.3" ? :xstring : :string_content }
+
     it 'produces a comment node surrounding a commented def' do
       result = parse_with_builder "# Foo\ndef foo; end"
       result.must_equal s(:program,
@@ -115,7 +119,7 @@ describe RipperRubyParser::CommentingRipperParser do
       result.must_equal s(:program,
                           s(:stmts,
                             s(:dyna_symbol,
-                              s(:xstring, s(:@tstring_content, 'foo', s(1, 2), ":'"))),
+                              s(dsym_string_type, s(:@tstring_content, 'foo', s(1, 2), ":'"))),
                             s(:comment,
                               '',
                               s(:def,
@@ -131,7 +135,7 @@ describe RipperRubyParser::CommentingRipperParser do
       result.must_equal s(:program,
                           s(:stmts,
                             s(:dyna_symbol,
-                              s(:xstring,
+                              s(dsym_string_type,
                                 s(:@tstring_content, 'foo', s(1, 2), ':"'),
                                 s(:string_embexpr,
                                   s(:stmts,


### PR DESCRIPTION
Fixes test failures on Ruby 2.6.3 and/or sexp_processor 4.12.1.