### PR TITLE
Update for minitest 5.12

### DIFF
--- a/ripper_ruby_parser.gemspec
+++ b/ripper_ruby_parser.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('sexp_processor', ['~> 4.10'])
 
-  s.add_development_dependency('minitest', ['~> 5.2'])
+  s.add_development_dependency('minitest', ['~> 5.6'])
   s.add_development_dependency('rake', ['~> 12.0'])
   s.add_development_dependency('ruby_parser', ['~> 3.13.1'])
   s.add_development_dependency('simplecov')

--- a/test/end_to_end/comments_test.rb
+++ b/test/end_to_end/comments_test.rb
@@ -49,11 +49,11 @@ describe 'Using RipperRubyParser and RubyParser' do
     end
 
     it 'gives the same result' do
-      imitation.must_equal original
+      _(imitation).must_equal original
     end
 
     it 'gives the same result with comments' do
-      to_comments(imitation).must_equal to_comments(original)
+      _(to_comments(imitation)).must_equal to_comments(original)
     end
   end
 end

--- a/test/end_to_end/comparison_test.rb
+++ b/test/end_to_end/comparison_test.rb
@@ -10,7 +10,7 @@ describe 'Using RipperRubyParser and RubyParser' do
     end
 
     it 'gives the same result with line numbers' do
-      program.must_be_parsed_as_before with_line_numbers: true
+      _(program).must_be_parsed_as_before with_line_numbers: true
     end
   end
 
@@ -36,7 +36,7 @@ describe 'Using RipperRubyParser and RubyParser' do
     end
 
     it 'gives the same result with line numbers' do
-      program.must_be_parsed_as_before with_line_numbers: true
+      _(program).must_be_parsed_as_before with_line_numbers: true
     end
   end
 
@@ -46,7 +46,7 @@ describe 'Using RipperRubyParser and RubyParser' do
     end
 
     it 'gives the same result with line numbers' do
-      program.must_be_parsed_as_before with_line_numbers: true
+      _(program).must_be_parsed_as_before with_line_numbers: true
     end
   end
 
@@ -64,7 +64,7 @@ describe 'Using RipperRubyParser and RubyParser' do
     end
 
     it 'gives the same result' do
-      program.must_be_parsed_as_before
+      _(program).must_be_parsed_as_before
     end
   end
 
@@ -88,7 +88,7 @@ describe 'Using RipperRubyParser and RubyParser' do
     end
 
     it 'gives the same result' do
-      program.must_be_parsed_as_before
+      _(program).must_be_parsed_as_before
     end
   end
 
@@ -98,7 +98,7 @@ describe 'Using RipperRubyParser and RubyParser' do
     end
 
     it 'gives the same result with line numbers' do
-      program.must_be_parsed_as_before with_line_numbers: true
+      _(program).must_be_parsed_as_before with_line_numbers: true
     end
   end
 end

--- a/test/end_to_end/lib_comparison_test.rb
+++ b/test/end_to_end/lib_comparison_test.rb
@@ -22,7 +22,7 @@ describe 'Using RipperRubyParser and RubyParser' do
         original = oldparser.parse program
         imitation = newparser.parse program
 
-        formatted(imitation).must_equal formatted(original)
+        _(formatted(imitation)).must_equal formatted(original)
       end
     end
   end

--- a/test/end_to_end/line_numbering_test.rb
+++ b/test/end_to_end/line_numbering_test.rb
@@ -21,11 +21,11 @@ describe 'Using RipperRubyParser and RubyParser' do
     end
 
     it 'gives the same result' do
-      program.must_be_parsed_as_before
+      _(program).must_be_parsed_as_before
     end
 
     it 'gives the same result with line numbers' do
-      program.must_be_parsed_as_before with_line_numbers: true
+      _(program).must_be_parsed_as_before with_line_numbers: true
     end
   end
 end

--- a/test/end_to_end/samples_comparison_test.rb
+++ b/test/end_to_end/samples_comparison_test.rb
@@ -7,7 +7,7 @@ describe 'Using RipperRubyParser and RubyParser' do
   Dir.glob(File.expand_path('../samples/*.rb', File.dirname(__FILE__))).each do |file|
     it "gives the same result for #{file}" do
       program = File.read file
-      program.must_be_parsed_as_before
+      _(program).must_be_parsed_as_before
     end
   end
 end

--- a/test/end_to_end/test_comparison_test.rb
+++ b/test/end_to_end/test_comparison_test.rb
@@ -25,7 +25,7 @@ describe 'Using RipperRubyParser and RubyParser' do
         original = oldparser.parse program
         imitation = newparser.parse copy
 
-        formatted(imitation).must_equal formatted(original)
+        _(formatted(imitation)).must_equal formatted(original)
       end
     end
   end

--- a/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
+++ b/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
@@ -19,7 +19,7 @@ describe RipperRubyParser::CommentingRipperParser do
 
     it 'produces a comment node surrounding a commented def' do
       result = parse_with_builder "# Foo\ndef foo; end"
-      result.must_equal s(:program,
+      _(result).must_equal s(:program,
                           s(:stmts,
                             s(:comment,
                               "# Foo\n",
@@ -33,7 +33,7 @@ describe RipperRubyParser::CommentingRipperParser do
 
     it 'produces a blank comment node surrounding a def that has no comment' do
       result = parse_with_builder 'def foo; end'
-      result.must_equal s(:program,
+      _(result).must_equal s(:program,
                           s(:stmts,
                             s(:comment,
                               '',
@@ -47,7 +47,7 @@ describe RipperRubyParser::CommentingRipperParser do
 
     it 'produces a comment node surrounding a commented class' do
       result = parse_with_builder "# Foo\nclass Foo; end"
-      result.must_equal s(:program,
+      _(result).must_equal s(:program,
                           s(:stmts,
                             s(:comment,
                               "# Foo\n",
@@ -61,7 +61,7 @@ describe RipperRubyParser::CommentingRipperParser do
 
     it 'produce a blank comment node surrounding a class that has no comment' do
       result = parse_with_builder 'class Foo; end'
-      result.must_equal s(:program,
+      _(result).must_equal s(:program,
                           s(:stmts,
                             s(:comment,
                               '',
@@ -75,7 +75,7 @@ describe RipperRubyParser::CommentingRipperParser do
 
     it 'produces a comment node surrounding a commented module' do
       result = parse_with_builder "# Foo\nmodule Foo; end"
-      result.must_equal s(:program,
+      _(result).must_equal s(:program,
                           s(:stmts,
                             s(:comment,
                               "# Foo\n",
@@ -88,7 +88,7 @@ describe RipperRubyParser::CommentingRipperParser do
 
     it 'produces a blank comment node surrounding a module that has no comment' do
       result = parse_with_builder 'module Foo; end'
-      result.must_equal s(:program,
+      _(result).must_equal s(:program,
                           s(:stmts,
                             s(:comment,
                               '',
@@ -101,7 +101,7 @@ describe RipperRubyParser::CommentingRipperParser do
 
     it 'is not confused by a symbol containing a keyword' do
       result = parse_with_builder ':class; def foo; end'
-      result.must_equal s(:program,
+      _(result).must_equal s(:program,
                           s(:stmts,
                             s(:symbol_literal, s(:symbol, s(:@kw, 'class', s(1, 1)))),
                             s(:comment,
@@ -116,7 +116,7 @@ describe RipperRubyParser::CommentingRipperParser do
 
     it 'is not confused by a dynamic symbol' do
       result = parse_with_builder ":'foo'; def bar; end"
-      result.must_equal s(:program,
+      _(result).must_equal s(:program,
                           s(:stmts,
                             s(:dyna_symbol,
                               s(dsym_string_type, s(:@tstring_content, 'foo', s(1, 2), ":'"))),
@@ -132,7 +132,7 @@ describe RipperRubyParser::CommentingRipperParser do
 
     it 'is not confused by a dynamic symbol containing a class definition' do
       result = parse_with_builder ":\"foo\#{class Bar;end}\""
-      result.must_equal s(:program,
+      _(result).must_equal s(:program,
                           s(:stmts,
                             s(:dyna_symbol,
                               s(dsym_string_type,
@@ -151,7 +151,7 @@ describe RipperRubyParser::CommentingRipperParser do
 
     it 'turns an embedded document into a comment node' do
       result = parse_with_builder "=begin Hello\nthere\n=end\nclass Foo; end"
-      result.must_equal s(:program,
+      _(result).must_equal s(:program,
                           s(:stmts,
                             s(:comment,
                               "=begin Hello\nthere\n=end\n",
@@ -166,45 +166,31 @@ describe RipperRubyParser::CommentingRipperParser do
 
   describe 'handling syntax errors' do
     it 'raises an error for an incomplete source' do
-      proc {
-        parse_with_builder 'def foo'
-      }.must_raise RipperRubyParser::SyntaxError
+      _(proc { parse_with_builder 'def foo' }).must_raise RipperRubyParser::SyntaxError
     end
 
     it 'raises an error for an invalid class name' do
-      proc {
-        parse_with_builder 'class foo; end'
-      }.must_raise RipperRubyParser::SyntaxError
+      _(proc { parse_with_builder 'class foo; end' }).must_raise RipperRubyParser::SyntaxError
     end
 
     it 'raises an error aliasing $1 as foo' do
-      proc {
-        parse_with_builder 'alias foo $1'
-      }.must_raise RipperRubyParser::SyntaxError
+      _(proc { parse_with_builder 'alias foo $1' }).must_raise RipperRubyParser::SyntaxError
     end
 
     it 'raises an error aliasing foo as $1' do
-      proc {
-        parse_with_builder 'alias $1 foo'
-      }.must_raise RipperRubyParser::SyntaxError
+      _(proc { parse_with_builder 'alias $1 foo' }).must_raise RipperRubyParser::SyntaxError
     end
 
     it 'raises an error aliasing $2 as $1' do
-      proc {
-        parse_with_builder 'alias $1 $2'
-      }.must_raise RipperRubyParser::SyntaxError
+      _(proc { parse_with_builder 'alias $1 $2' }).must_raise RipperRubyParser::SyntaxError
     end
 
     it 'raises an error assigning to $1' do
-      proc {
-        parse_with_builder '$1 = foo'
-      }.must_raise RipperRubyParser::SyntaxError
+      _(proc { parse_with_builder '$1 = foo' }).must_raise RipperRubyParser::SyntaxError
     end
 
     it 'raises an error using an invalid parameter name' do
-      proc {
-        parse_with_builder 'def foo(BAR); end'
-      }.must_raise RipperRubyParser::SyntaxError
+      _(proc { parse_with_builder 'def foo(BAR); end' }).must_raise RipperRubyParser::SyntaxError
     end
   end
 end

--- a/test/ripper_ruby_parser/parser_test.rb
+++ b/test/ripper_ruby_parser/parser_test.rb
@@ -7,36 +7,36 @@ describe RipperRubyParser::Parser do
   describe '#parse' do
     it 'returns an s-expression' do
       result = parser.parse 'foo'
-      result.must_be_instance_of Sexp
+      _(result).must_be_instance_of Sexp
     end
 
     describe 'for an empty program' do
       it 'returns nil' do
-        ''.must_be_parsed_as nil
+        _('').must_be_parsed_as nil
       end
     end
 
     describe 'for a class declaration' do
       it 'works with a namespaced class name' do
-        'class Foo::Bar; end'.
+        _('class Foo::Bar; end').
           must_be_parsed_as s(:class,
                               s(:colon2, s(:const, :Foo), :Bar),
                               nil)
       end
 
       it 'works for singleton classes' do
-        'class << self; end'.must_be_parsed_as s(:sclass, s(:self))
+        _('class << self; end').must_be_parsed_as s(:sclass, s(:self))
       end
     end
 
     describe 'for a module declaration' do
       it 'works with a simple module name' do
-        'module Foo; end'.
+        _('module Foo; end').
           must_be_parsed_as s(:module, :Foo)
       end
 
       it 'works with a namespaced module name' do
-        'module Foo::Bar; end'.
+        _('module Foo::Bar; end').
           must_be_parsed_as s(:module,
                               s(:colon2, s(:const, :Foo), :Bar))
       end
@@ -44,23 +44,23 @@ describe RipperRubyParser::Parser do
 
     describe 'for empty parentheses' do
       it 'works with lone ()' do
-        '()'.must_be_parsed_as s(:nil)
+        _('()').must_be_parsed_as s(:nil)
       end
     end
 
     describe 'for a begin..end block' do
       it 'works with no statements' do
-        'begin; end'.
+        _('begin; end').
           must_be_parsed_as s(:nil)
       end
 
       it 'works with one statement' do
-        'begin; foo; end'.
+        _('begin; foo; end').
           must_be_parsed_as s(:call, nil, :foo)
       end
 
       it 'works with multiple statements' do
-        'begin; foo; bar; end'.
+        _('begin; foo; bar; end').
           must_be_parsed_as s(:block,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar))
@@ -69,7 +69,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for arguments' do
       it 'works for a simple case with splat' do
-        'foo *bar'.
+        _('foo *bar').
           must_be_parsed_as s(:call,
                               nil,
                               :foo,
@@ -77,7 +77,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works for a multi-argument case with splat' do
-        'foo bar, *baz'.
+        _('foo bar, *baz').
           must_be_parsed_as s(:call,
                               nil,
                               :foo,
@@ -86,14 +86,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works for a simple case passing a block' do
-        'foo &bar'.
+        _('foo &bar').
           must_be_parsed_as s(:call, nil, :foo,
                               s(:block_pass,
                                 s(:call, nil, :bar)))
       end
 
       it 'works for a bare hash' do
-        'foo bar => baz'.
+        _('foo bar => baz').
           must_be_parsed_as s(:call, nil, :foo,
                               s(:hash,
                                 s(:call, nil, :bar),
@@ -103,7 +103,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for the __ENCODING__ keyword' do
       it 'evaluates to the equivalent of Encoding::UTF_8' do
-        '__ENCODING__'.
+        _('__ENCODING__').
           must_be_parsed_as s(:colon2, s(:const, :Encoding), :UTF_8)
       end
     end
@@ -111,7 +111,7 @@ describe RipperRubyParser::Parser do
     describe 'for the __FILE__ keyword' do
       describe 'when not passing a file name' do
         it "creates a string sexp with value '(string)'" do
-          '__FILE__'.
+          _('__FILE__').
             must_be_parsed_as s(:str, '(string)')
         end
       end
@@ -119,33 +119,33 @@ describe RipperRubyParser::Parser do
       describe 'when passing a file name' do
         it 'creates a string sexp with the file name' do
           result = parser.parse '__FILE__', 'foo'
-          result.must_equal s(:str, 'foo')
+          _(result).must_equal s(:str, 'foo')
         end
       end
     end
 
     describe 'for the __LINE__ keyword' do
       it 'creates a literal sexp with value of the line number' do
-        '__LINE__'.
+        _('__LINE__').
           must_be_parsed_as s(:lit, 1)
-        "\n__LINE__".
+        _("\n__LINE__").
           must_be_parsed_as s(:lit, 2)
       end
     end
 
     describe 'for the END keyword' do
       it 'converts to a :postexe iterator' do
-        'END { foo }'.
+        _('END { foo }').
           must_be_parsed_as s(:iter, s(:postexe), 0, s(:call, nil, :foo))
       end
 
       it 'works with an empty block' do
-        'END { }'.
+        _('END { }').
           must_be_parsed_as s(:iter, s(:postexe), 0)
       end
 
       it 'assigns correct line numbers' do
-        "END {\nfoo\n}".
+        _("END {\nfoo\n}").
           must_be_parsed_as s(:iter,
                               s(:postexe).line(1), 0,
                               s(:call, nil, :foo).line(2)).line(1),
@@ -153,7 +153,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'assigns correct line numbers to a embedded begin block' do
-        "END {\nbegin\nfoo\nend\n}".
+        _("END {\nbegin\nfoo\nend\n}").
           must_be_parsed_as s(:iter,
                               s(:postexe).line(1), 0,
                               s(:call, nil, :foo).line(3)).line(1),
@@ -163,17 +163,17 @@ describe RipperRubyParser::Parser do
 
     describe 'for the BEGIN keyword' do
       it 'converts to a :preexe iterator' do
-        'BEGIN { foo }'.
+        _('BEGIN { foo }').
           must_be_parsed_as s(:iter, s(:preexe), 0, s(:call, nil, :foo))
       end
 
       it 'works with an empty block' do
-        'BEGIN { }'.
+        _('BEGIN { }').
           must_be_parsed_as s(:iter, s(:preexe), 0)
       end
 
       it 'assigns correct line numbers' do
-        "BEGIN {\nfoo\n}".
+        _("BEGIN {\nfoo\n}").
           must_be_parsed_as s(:iter,
                               s(:preexe).line(1), 0,
                               s(:call, nil, :foo).line(2)).line(1),
@@ -181,7 +181,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'assigns correct line numbers to a embedded begin block' do
-        "BEGIN {\nbegin\nfoo\nend\n}".
+        _("BEGIN {\nbegin\nfoo\nend\n}").
           must_be_parsed_as s(:iter,
                               s(:preexe).line(1), 0,
                               s(:begin,
@@ -192,19 +192,19 @@ describe RipperRubyParser::Parser do
 
     describe 'for constant lookups' do
       it 'works when explicitely starting from the root namespace' do
-        '::Foo'.
+        _('::Foo').
           must_be_parsed_as s(:colon3, :Foo)
       end
 
       it 'works with a three-level constant lookup' do
-        'Foo::Bar::Baz'.
+        _('Foo::Bar::Baz').
           must_be_parsed_as s(:colon2,
                               s(:colon2, s(:const, :Foo), :Bar),
                               :Baz)
       end
 
       it 'works looking up a constant in a non-constant' do
-        'foo::Bar'.must_be_parsed_as s(:colon2,
+        _('foo::Bar').must_be_parsed_as s(:colon2,
                                        s(:call, nil, :foo),
                                        :Bar)
       end
@@ -212,37 +212,37 @@ describe RipperRubyParser::Parser do
 
     describe 'for variable references' do
       it 'works for self' do
-        'self'.
+        _('self').
           must_be_parsed_as s(:self)
       end
 
       it 'works for instance variables' do
-        '@foo'.
+        _('@foo').
           must_be_parsed_as s(:ivar, :@foo)
       end
 
       it 'works for global variables' do
-        '$foo'.
+        _('$foo').
           must_be_parsed_as s(:gvar, :$foo)
       end
 
       it 'works for regexp match references' do
-        '$1'.
+        _('$1').
           must_be_parsed_as s(:nth_ref, 1)
       end
 
-      specify { "$'".must_be_parsed_as s(:back_ref, :"'") }
-      specify { '$&'.must_be_parsed_as s(:back_ref, :"&") }
+      specify { _("$'").must_be_parsed_as s(:back_ref, :"'") }
+      specify { _('$&').must_be_parsed_as s(:back_ref, :"&") }
 
       it 'works for class variables' do
-        '@@foo'.
+        _('@@foo').
           must_be_parsed_as s(:cvar, :@@foo)
       end
     end
 
     describe 'for expressions' do
       it 'handles assignment inside binary operator expressions' do
-        'foo + (bar = baz)'.
+        _('foo + (bar = baz)').
           must_be_parsed_as s(:call,
                               s(:call, nil, :foo),
                               :+,
@@ -252,7 +252,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles assignment inside unary operator expressions' do
-        '+(foo = bar)'.
+        _('+(foo = bar)').
           must_be_parsed_as s(:call,
                               s(:lasgn, :foo, s(:call, nil, :bar)),
                               :+@)
@@ -264,39 +264,39 @@ describe RipperRubyParser::Parser do
     describe 'for comments' do
       it 'handles method comments' do
         result = parser.parse "# Foo\ndef foo; end"
-        result.must_equal s(:defn,
+        _(result).must_equal s(:defn,
                             :foo,
                             s(:args), s(:nil))
-        result.comments.must_equal "# Foo\n"
+        _(result.comments).must_equal "# Foo\n"
       end
 
       it 'handles comments for methods with explicit receiver' do
         result = parser.parse "# Foo\ndef foo.bar; end"
-        result.must_equal s(:defs,
+        _(result).must_equal s(:defs,
                             s(:call, nil, :foo),
                             :bar,
                             s(:args),
                             s(:nil))
-        result.comments.must_equal "# Foo\n"
+        _(result.comments).must_equal "# Foo\n"
       end
 
       it 'matches comments to the correct entity' do
         result = parser.parse "# Foo\nclass Foo\n# Bar\ndef bar\nend\nend"
-        result.must_equal s(:class, :Foo, nil,
+        _(result).must_equal s(:class, :Foo, nil,
                             s(:defn, :bar,
                               s(:args), s(:nil)))
-        result.comments.must_equal "# Foo\n"
+        _(result.comments).must_equal "# Foo\n"
         defn = result[3]
-        defn.sexp_type.must_equal :defn
-        defn.comments.must_equal "# Bar\n"
+        _(defn.sexp_type).must_equal :defn
+        _(defn.comments).must_equal "# Bar\n"
       end
 
       it 'combines multi-line comments' do
         result = parser.parse "# Foo\n# Bar\ndef foo; end"
-        result.must_equal s(:defn,
+        _(result).must_equal s(:defn,
                             :foo,
                             s(:args), s(:nil))
-        result.comments.must_equal "# Foo\n# Bar\n"
+        _(result.comments).must_equal "# Foo\n# Bar\n"
       end
 
       it 'drops comments inside method bodies' do
@@ -314,53 +314,53 @@ describe RipperRubyParser::Parser do
             end
           end
         END
-        result.must_equal s(:class,
+        _(result).must_equal s(:class,
                             :Foo,
                             nil,
                             s(:defn, :foo, s(:args), s(:call, nil, :bar)),
                             s(:defn, :bar, s(:args), s(:call, nil, :baz)))
-        result.comments.must_equal "# Foo\n"
-        result[3].comments.must_equal "# foo\n"
-        result[4].comments.must_equal "# bar\n"
+        _(result.comments).must_equal "# Foo\n"
+        _(result[3].comments).must_equal "# foo\n"
+        _(result[4].comments).must_equal "# bar\n"
       end
 
       it 'handles use of singleton class inside methods' do
         result = parser.parse "# Foo\ndef bar\nclass << self\nbaz\nend\nend"
-        result.must_equal s(:defn,
+        _(result).must_equal s(:defn,
                             :bar,
                             s(:args),
                             s(:sclass, s(:self),
                               s(:call, nil, :baz)))
-        result.comments.must_equal "# Foo\n"
+        _(result.comments).must_equal "# Foo\n"
       end
 
       # TODO: Prefer assigning comment to the BEGIN instead
       it 'assigns comments on BEGIN blocks to the following item' do
         result = parser.parse "# Bar\nBEGIN { }\n# Foo\nclass Bar\n# foo\ndef foo; end\nend"
-        result.must_equal s(:block,
+        _(result).must_equal s(:block,
                             s(:iter, s(:preexe), 0),
                             s(:class, :Bar, nil,
                               s(:defn, :foo, s(:args), s(:nil))))
-        result[2].comments.must_equal "# Bar\n# Foo\n"
-        result[2][3].comments.must_equal "# foo\n"
+        _(result[2].comments).must_equal "# Bar\n# Foo\n"
+        _(result[2][3].comments).must_equal "# foo\n"
       end
 
       it 'assigns comments on multiple BEGIN blocks to the following item' do
         result = parser.parse "# Bar\nBEGIN { }\n# Baz\nBEGIN { }\n# Foo\ndef foo; end"
-        result.must_equal s(:block,
+        _(result).must_equal s(:block,
                             s(:iter, s(:preexe), 0),
                             s(:iter, s(:preexe), 0),
                             s(:defn, :foo, s(:args), s(:nil)))
-        result[3].comments.must_equal "# Bar\n# Baz\n# Foo\n"
+        _(result[3].comments).must_equal "# Bar\n# Baz\n# Foo\n"
       end
 
       it 'assigns comments on BEGIN blocks to the first following item' do
         result = parser.parse "# Bar\nBEGIN { }\n# Baz\nBEGIN { }\n# Foo\ndef foo; end"
-        result.must_equal s(:block,
+        _(result).must_equal s(:block,
                             s(:iter, s(:preexe), 0),
                             s(:iter, s(:preexe), 0),
                             s(:defn, :foo, s(:args), s(:nil)))
-        result[3].comments.must_equal "# Bar\n# Baz\n# Foo\n"
+        _(result[3].comments).must_equal "# Bar\n# Baz\n# Foo\n"
       end
     end
 
@@ -369,59 +369,59 @@ describe RipperRubyParser::Parser do
     describe 'assigning line numbers' do
       it 'works for a plain method call' do
         result = parser.parse 'foo'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a method call with parentheses' do
         result = parser.parse 'foo()'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a method call with receiver' do
         result = parser.parse 'foo.bar'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a method call with receiver and arguments' do
         result = parser.parse 'foo.bar baz'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a method call with arguments' do
         result = parser.parse 'foo bar'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a block with two lines' do
         result = parser.parse "foo\nbar\n"
-        result.sexp_type.must_equal :block
-        result[1].line.must_equal 1
-        result[2].line.must_equal 2
-        result.line.must_equal 1
+        _(result.sexp_type).must_equal :block
+        _(result[1].line).must_equal 1
+        _(result[2].line).must_equal 2
+        _(result.line).must_equal 1
       end
 
       it 'works for a constant reference' do
         result = parser.parse 'Foo'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for an instance variable' do
         result = parser.parse '@foo'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a global variable' do
         result = parser.parse '$foo'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a class variable' do
         result = parser.parse '@@foo'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a local variable' do
-        "foo = bar\nfoo\n".
+        _("foo = bar\nfoo\n").
           must_be_parsed_as s(:block,
                               s(:lasgn, :foo, s(:call, nil, :bar).line(1)).line(1),
                               s(:lvar, :foo).line(2)).line(1),
@@ -430,86 +430,86 @@ describe RipperRubyParser::Parser do
 
       it 'works for an integer literal' do
         result = parser.parse '42'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a float literal' do
         result = parser.parse '3.14'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a range literal' do
         result = parser.parse '0..4'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for an exclusive range literal' do
         result = parser.parse '0...4'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a symbol literal' do
         result = parser.parse ':foo'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a keyword-like symbol literal' do
         result = parser.parse ':and'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a string literal' do
         result = parser.parse '"foo"'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a backtick string literal' do
         result = parser.parse '`foo`'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a plain regexp literal' do
         result = parser.parse '/foo/'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a regular expression back reference' do
         result = parser.parse '$1'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for self' do
         result = parser.parse 'self'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for __FILE__' do
         result = parser.parse '__FILE__'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for nil' do
         result = parser.parse 'nil'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a class definition' do
         result = parser.parse 'class Foo; end'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a module definition' do
         result = parser.parse 'module Foo; end'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'works for a method definition' do
         result = parser.parse 'def foo; end'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
 
       it 'assigns line numbers to nested sexps without their own line numbers' do
-        "foo(bar) do\nnext baz\nend\n".
+        _("foo(bar) do\nnext baz\nend\n").
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo, s(:call, nil, :bar).line(1)).line(1),
                               0,
@@ -520,12 +520,12 @@ describe RipperRubyParser::Parser do
       describe 'when a line number is passed' do
         it 'shifts all line numbers as appropriate' do
           result = parser.parse "foo\nbar\n", '(string)', 3
-          result.must_equal s(:block,
+          _(result).must_equal s(:block,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar))
-          result.line.must_equal 3
-          result[1].line.must_equal 3
-          result[2].line.must_equal 4
+          _(result.line).must_equal 3
+          _(result[1].line).must_equal 3
+          _(result[2].line).must_equal 4
         end
       end
     end
@@ -537,7 +537,7 @@ describe RipperRubyParser::Parser do
       outer = s(:bar, s(:baz, s(:qux, inner)))
       outer.line = 42
       parser.send :trickle_down_line_numbers, outer
-      inner.line.must_equal 42
+      _(inner.line).must_equal 42
     end
   end
 
@@ -547,7 +547,7 @@ describe RipperRubyParser::Parser do
       inner.line = 42
       outer = s(:bar, s(:baz, s(:qux, inner)))
       parser.send :trickle_up_line_numbers, outer
-      outer.line.must_equal 42
+      _(outer.line).must_equal 42
     end
   end
 end

--- a/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
@@ -8,27 +8,27 @@ describe RipperRubyParser::Parser do
   describe '#parse' do
     describe 'for single assignment' do
       it 'works when assigning to a namespaced constant' do
-        'Foo::Bar = baz'.
+        _('Foo::Bar = baz').
           must_be_parsed_as s(:cdecl,
                               s(:colon2, s(:const, :Foo), :Bar),
                               s(:call, nil, :baz))
       end
 
       it 'works when assigning to constant in the root namespace' do
-        '::Foo = bar'.
+        _('::Foo = bar').
           must_be_parsed_as s(:cdecl,
                               s(:colon3, :Foo),
                               s(:call, nil, :bar))
       end
 
       it 'works with blocks' do
-        'foo = begin; bar; end'.
+        _('foo = begin; bar; end').
           must_be_parsed_as s(:lasgn, :foo, s(:call, nil, :bar))
       end
 
       describe 'with a right-hand splat' do
         it 'works in the simple case' do
-          'foo = *bar'.
+          _('foo = *bar').
             must_be_parsed_as s(:lasgn, :foo,
                                 s(:svalue,
                                   s(:splat,
@@ -36,7 +36,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works with blocks' do
-          'foo = *begin; bar; end'.
+          _('foo = *begin; bar; end').
             must_be_parsed_as s(:lasgn, :foo,
                                 s(:svalue, s(:splat, s(:call, nil, :bar))))
         end
@@ -44,7 +44,7 @@ describe RipperRubyParser::Parser do
 
       describe 'with several items on the right hand side' do
         it 'works in the simple case' do
-          'foo = bar, baz'.
+          _('foo = bar, baz').
             must_be_parsed_as s(:lasgn, :foo,
                                 s(:svalue,
                                   s(:array,
@@ -53,7 +53,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works with a splat' do
-          'foo = bar, *baz'.
+          _('foo = bar, *baz').
             must_be_parsed_as s(:lasgn, :foo,
                                 s(:svalue,
                                   s(:array,
@@ -65,7 +65,7 @@ describe RipperRubyParser::Parser do
 
       describe 'with an array literal on the right hand side' do
         specify do
-          'foo = [bar, baz]'.
+          _('foo = [bar, baz]').
             must_be_parsed_as s(:lasgn, :foo,
                                 s(:array,
                                   s(:call, nil, :bar),
@@ -74,21 +74,21 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works when assigning to an instance variable' do
-        '@foo = bar'.
+        _('@foo = bar').
           must_be_parsed_as s(:iasgn,
                               :@foo,
                               s(:call, nil, :bar))
       end
 
       it 'works when assigning to a constant' do
-        'FOO = bar'.
+        _('FOO = bar').
           must_be_parsed_as s(:cdecl,
                               :FOO,
                               s(:call, nil, :bar))
       end
 
       it 'works when assigning to a collection element' do
-        'foo[bar] = baz'.
+        _('foo[bar] = baz').
           must_be_parsed_as s(:attrasgn,
                               s(:call, nil, :foo),
                               :[]=,
@@ -97,7 +97,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works when assigning to an attribute' do
-        'foo.bar = baz'.
+        _('foo.bar = baz').
           must_be_parsed_as s(:attrasgn,
                               s(:call, nil, :foo),
                               :bar=,
@@ -106,21 +106,21 @@ describe RipperRubyParser::Parser do
 
       describe 'when assigning to a class variable' do
         it 'works outside a method' do
-          '@@foo = bar'.
+          _('@@foo = bar').
             must_be_parsed_as s(:cvdecl,
                                 :@@foo,
                                 s(:call, nil, :bar))
         end
 
         it 'works inside a method' do
-          'def foo; @@bar = baz; end'.
+          _('def foo; @@bar = baz; end').
             must_be_parsed_as s(:defn,
                                 :foo, s(:args),
                                 s(:cvasgn, :@@bar, s(:call, nil, :baz)))
         end
 
         it 'works inside a method with a receiver' do
-          'def self.foo; @@bar = baz; end'.
+          _('def self.foo; @@bar = baz; end').
             must_be_parsed_as s(:defs,
                                 s(:self),
                                 :foo, s(:args),
@@ -128,7 +128,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works inside method arguments' do
-          'def foo(bar = (@@baz = qux)); end'.
+          _('def foo(bar = (@@baz = qux)); end').
             must_be_parsed_as s(:defn,
                                 :foo,
                                 s(:args,
@@ -138,7 +138,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works inside method arguments of a singleton method' do
-          'def self.foo(bar = (@@baz = qux)); end'.
+          _('def self.foo(bar = (@@baz = qux)); end').
             must_be_parsed_as s(:defs,
                                 s(:self),
                                 :foo,
@@ -149,7 +149,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works inside the receiver in a method definition' do
-          'def (bar = (@@baz = qux)).foo; end'.
+          _('def (bar = (@@baz = qux)).foo; end').
             must_be_parsed_as s(:defs,
                                 s(:lasgn, :bar,
                                   s(:cvdecl, :@@baz,
@@ -159,7 +159,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works when assigning to a global variable' do
-        '$foo = bar'.
+        _('$foo = bar').
           must_be_parsed_as s(:gasgn,
                               :$foo,
                               s(:call, nil, :bar))
@@ -167,7 +167,7 @@ describe RipperRubyParser::Parser do
 
       describe 'with a rescue modifier' do
         it 'works with assigning a bare method call' do
-          'foo = bar rescue baz'.
+          _('foo = bar rescue baz').
             must_be_parsed_as s(:lasgn, :foo,
                                 s(:rescue,
                                   s(:call, nil, :bar),
@@ -175,7 +175,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works with a method call with argument' do
-          'foo = bar(baz) rescue qux'.
+          _('foo = bar(baz) rescue qux').
             must_be_parsed_as s(:lasgn, :foo,
                                 s(:rescue,
                                   s(:call, nil, :bar, s(:call, nil, :baz)),
@@ -193,7 +193,7 @@ describe RipperRubyParser::Parser do
                            s(:call, nil, :bar, s(:call, nil, :baz)),
                            s(:resbody, s(:array), s(:call, nil, :qux))))
                      end
-          'foo = bar baz rescue qux'.must_be_parsed_as expected
+          _('foo = bar baz rescue qux').must_be_parsed_as expected
         end
 
         it 'works with a class method call with argument without brackets' do
@@ -207,7 +207,7 @@ describe RipperRubyParser::Parser do
                            s(:call, s(:const, :Bar), :baz, s(:call, nil, :qux)),
                            s(:resbody, s(:array), s(:call, nil, :quuz))))
                      end
-          'foo = Bar.baz qux rescue quuz'.
+          _('foo = Bar.baz qux rescue quuz').
             must_be_parsed_as expected
         end
 
@@ -222,7 +222,7 @@ describe RipperRubyParser::Parser do
                            s(:call, nil, :bar, s(:call, nil, :baz)),
                            s(:resbody, s(:array), s(:call, nil, :qux))))
                      end
-          'foo = bar baz rescue qux'.must_be_parsed_as expected
+          _('foo = bar baz rescue qux').must_be_parsed_as expected
         end
 
         it 'works with a class method call with argument without brackets' do
@@ -236,27 +236,27 @@ describe RipperRubyParser::Parser do
                            s(:call, s(:const, :Bar), :baz, s(:call, nil, :qux)),
                            s(:resbody, s(:array), s(:call, nil, :quuz))))
                      end
-          'foo = Bar.baz qux rescue quuz'.
+          _('foo = Bar.baz qux rescue quuz').
             must_be_parsed_as expected
         end
       end
 
       it 'sets the correct line numbers' do
         result = parser.parse 'foo = {}'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
     end
 
     describe 'for multiple assignment' do
       specify do
-        'foo, * = bar'.
+        _('foo, * = bar').
           must_be_parsed_as s(:masgn,
                               s(:array, s(:lasgn, :foo), s(:splat)),
                               s(:to_ary, s(:call, nil, :bar)))
       end
 
       specify do
-        '(foo, *bar) = baz'.
+        _('(foo, *bar) = baz').
           must_be_parsed_as s(:masgn,
                               s(:array,
                                 s(:lasgn, :foo),
@@ -265,7 +265,7 @@ describe RipperRubyParser::Parser do
       end
 
       specify do
-        '*foo, bar = baz'.
+        _('*foo, bar = baz').
           must_be_parsed_as s(:masgn,
                               s(:array,
                                 s(:splat, s(:lasgn, :foo)),
@@ -274,14 +274,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with blocks' do
-        'foo, bar = begin; baz; end'.
+        _('foo, bar = begin; baz; end').
           must_be_parsed_as s(:masgn,
                               s(:array, s(:lasgn, :foo), s(:lasgn, :bar)),
                               s(:to_ary, s(:call, nil, :baz)))
       end
 
       it 'works with a rescue modifier' do
-        'foo, bar = baz rescue qux'.
+        _('foo, bar = baz rescue qux').
           must_be_parsed_as s(:rescue,
                               s(:masgn,
                                 s(:array, s(:lasgn, :foo), s(:lasgn, :bar)),
@@ -290,7 +290,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works the same number of items on each side' do
-        'foo, bar = baz, qux'.
+        _('foo, bar = baz, qux').
           must_be_parsed_as s(:masgn,
                               s(:array, s(:lasgn, :foo), s(:lasgn, :bar)),
                               s(:array,
@@ -299,14 +299,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a single item on the right-hand side' do
-        'foo, bar = baz'.
+        _('foo, bar = baz').
           must_be_parsed_as s(:masgn,
                               s(:array, s(:lasgn, :foo), s(:lasgn, :bar)),
                               s(:to_ary, s(:call, nil, :baz)))
       end
 
       it 'works with left-hand splat' do
-        'foo, *bar = baz, qux'.
+        _('foo, *bar = baz, qux').
           must_be_parsed_as s(:masgn,
                               s(:array, s(:lasgn, :foo), s(:splat, s(:lasgn, :bar))),
                               s(:array,
@@ -315,14 +315,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with parentheses around the left-hand side' do
-        '(foo, bar) = baz'.
+        _('(foo, bar) = baz').
           must_be_parsed_as s(:masgn,
                               s(:array, s(:lasgn, :foo), s(:lasgn, :bar)),
                               s(:to_ary, s(:call, nil, :baz)))
       end
 
       it 'works with complex destructuring' do
-        'foo, (bar, baz) = qux'.
+        _('foo, (bar, baz) = qux').
           must_be_parsed_as s(:masgn,
                               s(:array,
                                 s(:lasgn, :foo),
@@ -334,7 +334,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with complex destructuring of the value' do
-        'foo, (bar, baz) = [qux, [quz, quuz]]'.
+        _('foo, (bar, baz) = [qux, [quz, quuz]]').
           must_be_parsed_as s(:masgn,
                               s(:array,
                                 s(:lasgn, :foo),
@@ -351,7 +351,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with destructuring with multiple levels' do
-        '((foo, bar)) = baz'.
+        _('((foo, bar)) = baz').
           must_be_parsed_as s(:masgn,
                               s(:array,
                                 s(:masgn,
@@ -362,21 +362,21 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with instance variables' do
-        '@foo, @bar = baz'.
+        _('@foo, @bar = baz').
           must_be_parsed_as s(:masgn,
                               s(:array, s(:iasgn, :@foo), s(:iasgn, :@bar)),
                               s(:to_ary, s(:call, nil, :baz)))
       end
 
       it 'works with class variables' do
-        '@@foo, @@bar = baz'.
+        _('@@foo, @@bar = baz').
           must_be_parsed_as s(:masgn,
                               s(:array, s(:cvdecl, :@@foo), s(:cvdecl, :@@bar)),
                               s(:to_ary, s(:call, nil, :baz)))
       end
 
       it 'works with attributes' do
-        'foo.bar, foo.baz = qux'.
+        _('foo.bar, foo.baz = qux').
           must_be_parsed_as s(:masgn,
                               s(:array,
                                 s(:attrasgn, s(:call, nil, :foo), :bar=),
@@ -385,7 +385,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with collection elements' do
-        'foo[1], bar[2] = baz'.
+        _('foo[1], bar[2] = baz').
           must_be_parsed_as s(:masgn,
                               s(:array,
                                 s(:attrasgn,
@@ -396,14 +396,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with constants' do
-        'Foo, Bar = baz'.
+        _('Foo, Bar = baz').
           must_be_parsed_as s(:masgn,
                               s(:array, s(:cdecl, :Foo), s(:cdecl, :Bar)),
                               s(:to_ary, s(:call, nil, :baz)))
       end
 
       it 'works with instance variables and splat' do
-        '@foo, *@bar = baz'.
+        _('@foo, *@bar = baz').
           must_be_parsed_as s(:masgn,
                               s(:array,
                                 s(:iasgn, :@foo),
@@ -412,14 +412,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a right-hand single splat' do
-        'foo, bar = *baz'.
+        _('foo, bar = *baz').
           must_be_parsed_as s(:masgn,
                               s(:array, s(:lasgn, :foo), s(:lasgn, :bar)),
                               s(:splat, s(:call, nil, :baz)))
       end
 
       it 'works with a splat in a list of values on the right hand' do
-        'foo, bar = baz, *qux'.
+        _('foo, bar = baz, *qux').
           must_be_parsed_as s(:masgn,
                               s(:array, s(:lasgn, :foo), s(:lasgn, :bar)),
                               s(:array,
@@ -428,7 +428,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a right-hand single splat with begin..end block' do
-        'foo, bar = *begin; baz; end'.
+        _('foo, bar = *begin; baz; end').
           must_be_parsed_as s(:masgn,
                               s(:array, s(:lasgn, :foo), s(:lasgn, :bar)),
                               s(:splat,
@@ -437,13 +437,13 @@ describe RipperRubyParser::Parser do
 
       it 'sets the correct line numbers' do
         result = parser.parse 'foo, bar = {}, {}'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
     end
 
     describe 'for assignment to a collection element' do
       it 'handles multiple indices' do
-        'foo[bar, baz] = qux'.
+        _('foo[bar, baz] = qux').
           must_be_parsed_as s(:attrasgn,
                               s(:call, nil, :foo),
                               :[]=,
@@ -455,7 +455,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for operator assignment' do
       it 'works with +=' do
-        'foo += bar'.
+        _('foo += bar').
           must_be_parsed_as s(:lasgn, :foo,
                               s(:call, s(:lvar, :foo),
                                 :+,
@@ -463,7 +463,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with -=' do
-        'foo -= bar'.
+        _('foo -= bar').
           must_be_parsed_as s(:lasgn, :foo,
                               s(:call, s(:lvar, :foo),
                                 :-,
@@ -471,7 +471,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with *=' do
-        'foo *= bar'.
+        _('foo *= bar').
           must_be_parsed_as s(:lasgn, :foo,
                               s(:call, s(:lvar, :foo),
                                 :*,
@@ -479,7 +479,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with /=' do
-        'foo /= bar'.
+        _('foo /= bar').
           must_be_parsed_as s(:lasgn, :foo,
                               s(:call,
                                 s(:lvar, :foo), :/,
@@ -487,7 +487,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with ||=' do
-        'foo ||= bar'.
+        _('foo ||= bar').
           must_be_parsed_as s(:op_asgn_or,
                               s(:lvar, :foo),
                               s(:lasgn, :foo,
@@ -495,7 +495,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works when assigning to an instance variable' do
-        '@foo += bar'.
+        _('@foo += bar').
           must_be_parsed_as s(:iasgn, :@foo,
                               s(:call,
                                 s(:ivar, :@foo), :+,
@@ -503,19 +503,19 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with boolean operators' do
-        'foo &&= bar'.
+        _('foo &&= bar').
           must_be_parsed_as s(:op_asgn_and,
                               s(:lvar, :foo), s(:lasgn, :foo, s(:call, nil, :bar)))
       end
 
       it 'works with boolean operators and blocks' do
-        'foo &&= begin; bar; end'.
+        _('foo &&= begin; bar; end').
           must_be_parsed_as s(:op_asgn_and,
                               s(:lvar, :foo), s(:lasgn, :foo, s(:call, nil, :bar)))
       end
 
       it 'works with arithmetic operators and blocks' do
-        'foo += begin; bar; end'.
+        _('foo += begin; bar; end').
           must_be_parsed_as s(:lasgn, :foo,
                               s(:call, s(:lvar, :foo), :+, s(:call, nil, :bar)))
       end
@@ -523,7 +523,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for operator assignment to an attribute' do
       it 'works with +=' do
-        'foo.bar += baz'.
+        _('foo.bar += baz').
           must_be_parsed_as s(:op_asgn2,
                               s(:call, nil, :foo),
                               :bar=, :+,
@@ -531,7 +531,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with ||=' do
-        'foo.bar ||= baz'.
+        _('foo.bar ||= baz').
           must_be_parsed_as s(:op_asgn2,
                               s(:call, nil, :foo),
                               :bar=, :'||',
@@ -541,7 +541,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for operator assignment to a collection element' do
       it 'works with +=' do
-        'foo[bar] += baz'.
+        _('foo[bar] += baz').
           must_be_parsed_as s(:op_asgn1,
                               s(:call, nil, :foo),
                               s(:arglist, s(:call, nil, :bar)),
@@ -550,7 +550,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with ||=' do
-        'foo[bar] ||= baz'.
+        _('foo[bar] ||= baz').
           must_be_parsed_as s(:op_asgn1,
                               s(:call, nil, :foo),
                               s(:arglist, s(:call, nil, :bar)),
@@ -559,7 +559,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles multiple indices' do
-        'foo[bar, baz] += qux'.
+        _('foo[bar, baz] += qux').
           must_be_parsed_as s(:op_asgn1,
                               s(:call, nil, :foo),
                               s(:arglist,
@@ -570,7 +570,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a function call without parentheses' do
-        'foo[bar] += baz qux'.
+        _('foo[bar] += baz qux').
           must_be_parsed_as s(:op_asgn1,
                               s(:call, nil, :foo),
                               s(:arglist, s(:call, nil, :bar)),
@@ -579,7 +579,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a function call with parentheses' do
-        'foo[bar] += baz(qux)'.
+        _('foo[bar] += baz(qux)').
           must_be_parsed_as s(:op_asgn1,
                               s(:call, nil, :foo),
                               s(:arglist, s(:call, nil, :bar)),
@@ -588,7 +588,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a method call without parentheses' do
-        'foo[bar] += baz.qux quuz'.
+        _('foo[bar] += baz.qux quuz').
           must_be_parsed_as s(:op_asgn1,
                               s(:call, nil, :foo),
                               s(:arglist, s(:call, nil, :bar)),
@@ -597,7 +597,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a method call with parentheses' do
-        'foo[bar] += baz.qux(quuz)'.
+        _('foo[bar] += baz.qux(quuz)').
           must_be_parsed_as s(:op_asgn1,
                               s(:call, nil, :foo),
                               s(:arglist, s(:call, nil, :bar)),
@@ -606,7 +606,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a function call without parentheses in extra compatible mode' do
-        'foo[bar] += baz qux'.
+        _('foo[bar] += baz qux').
           must_be_parsed_as s(:op_asgn1,
                               s(:call, nil, :foo),
                               s(:array, s(:call, nil, :bar)),
@@ -616,7 +616,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a function call with parentheses in extra compatible mode' do
-        'foo[bar] += baz(qux)'.
+        _('foo[bar] += baz(qux)').
           must_be_parsed_as s(:op_asgn1,
                               s(:call, nil, :foo),
                               s(:arglist, s(:call, nil, :bar)),
@@ -626,7 +626,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a method call without parentheses in extra compatible mode' do
-        'foo[bar] += baz.qux quuz'.
+        _('foo[bar] += baz.qux quuz').
           must_be_parsed_as s(:op_asgn1,
                               s(:call, nil, :foo),
                               s(:array, s(:call, nil, :bar)),
@@ -636,7 +636,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a method call with parentheses in extra compatible mode' do
-        'foo[bar] += baz.qux(quuz)'.
+        _('foo[bar] += baz.qux(quuz)').
           must_be_parsed_as s(:op_asgn1,
                               s(:call, nil, :foo),
                               s(:arglist, s(:call, nil, :bar)),

--- a/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
@@ -6,14 +6,14 @@ describe RipperRubyParser::Parser do
   describe '#parse' do
     describe 'for do blocks' do
       it 'works with no statements in the block body' do
-        'foo do; end'.
+        _('foo do; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0)
       end
 
       it 'works with redo' do
-        'foo do; redo; end'.
+        _('foo do; redo; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -21,7 +21,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with nested begin..end' do
-        'foo do; begin; bar; end; end;'.
+        _('foo do; begin; bar; end; end;').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -29,7 +29,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with nested begin..end plus other statements' do
-        'foo do; bar; begin; baz; end; end;'.
+        _('foo do; bar; begin; baz; end; end;').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -41,7 +41,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for brace blocks' do
       it 'works with no statements in the block body' do
-        'foo { }'.
+        _('foo { }').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0)
@@ -50,7 +50,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for block parameters' do
       specify do
-        'foo do |(bar, baz)| end'.
+        _('foo do |(bar, baz)| end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args,
@@ -58,7 +58,7 @@ describe RipperRubyParser::Parser do
       end
 
       specify do
-        'foo do |(bar, *baz)| end'.
+        _('foo do |(bar, *baz)| end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args,
@@ -66,21 +66,21 @@ describe RipperRubyParser::Parser do
       end
 
       specify do
-        'foo do |bar,*| end'.
+        _('foo do |bar,*| end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args, :bar, :"*"))
       end
 
       specify do
-        'foo do |bar, &baz| end'.
+        _('foo do |bar, &baz| end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args, :bar, :"&baz"))
       end
 
       it 'handles absent parameter specs' do
-        'foo do; bar; end'.
+        _('foo do; bar; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -88,7 +88,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles empty parameter specs' do
-        'foo do ||; bar; end'.
+        _('foo do ||; bar; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args),
@@ -96,35 +96,35 @@ describe RipperRubyParser::Parser do
       end
 
       it 'ignores a trailing comma in the block parameters' do
-        'foo do |bar, | end'.
+        _('foo do |bar, | end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args, :bar))
       end
 
       it 'works with zero arguments' do
-        'foo do ||; end'.
+        _('foo do ||; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args))
       end
 
       it 'works with one argument' do
-        'foo do |bar|; end'.
+        _('foo do |bar|; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args, :bar))
       end
 
       it 'works with multiple arguments' do
-        'foo do |bar, baz|; end'.
+        _('foo do |bar, baz|; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args, :bar, :baz))
       end
 
       it 'works with an argument with a default value' do
-        'foo do |bar=baz|; end'.
+        _('foo do |bar=baz|; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args,
@@ -132,7 +132,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a keyword argument with no default value' do
-        'foo do |bar:|; end'.
+        _('foo do |bar:|; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args,
@@ -140,7 +140,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a keyword argument with a default value' do
-        'foo do |bar: baz|; end'.
+        _('foo do |bar: baz|; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args,
@@ -148,21 +148,21 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a single splat argument' do
-        'foo do |*bar|; end'.
+        _('foo do |*bar|; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args, :"*bar"))
       end
 
       it 'works with a combination of regular arguments and a splat argument' do
-        'foo do |bar, *baz|; end'.
+        _('foo do |bar, *baz|; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args, :bar, :"*baz"))
       end
 
       it 'works with a kwrest argument' do
-        'foo do |**bar|; baz bar; end'.
+        _('foo do |**bar|; baz bar; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args, :"**bar"),
@@ -171,14 +171,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a regular argument after a splat argument' do
-        'foo do |*bar, baz|; end'.
+        _('foo do |*bar, baz|; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args, :"*bar", :baz))
       end
 
       it 'works with a combination of regular arguments and a kwrest argument' do
-        'foo do |bar, **baz|; qux bar, baz; end'.
+        _('foo do |bar, **baz|; qux bar, baz; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               s(:args, :bar, :"**baz"),
@@ -190,22 +190,22 @@ describe RipperRubyParser::Parser do
 
     describe 'for begin' do
       it 'works for an empty begin..end block' do
-        'begin end'.must_be_parsed_as s(:nil)
+        _('begin end').must_be_parsed_as s(:nil)
       end
 
       it 'works for a simple begin..end block' do
-        'begin; foo; end'.must_be_parsed_as s(:call, nil, :foo)
+        _('begin; foo; end').must_be_parsed_as s(:call, nil, :foo)
       end
 
       it 'works for begin..end block with more than one statement' do
-        'begin; foo; bar; end'.
+        _('begin; foo; bar; end').
           must_be_parsed_as s(:block,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar))
       end
 
       it 'keeps :begin for the truepart of a postfix if' do
-        'begin; foo; end if bar'.
+        _('begin; foo; end if bar').
           must_be_parsed_as s(:if,
                               s(:call, nil, :bar),
                               s(:begin, s(:call, nil, :foo)),
@@ -213,7 +213,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'keeps :begin for the falsepart of a postfix unless' do
-        'begin; foo; end unless bar'.
+        _('begin; foo; end unless bar').
           must_be_parsed_as s(:if,
                               s(:call, nil, :bar),
                               nil,
@@ -223,7 +223,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for rescue/else' do
       it 'works for a block with multiple rescue statements' do
-        'begin foo; rescue; bar; rescue; baz; end'.
+        _('begin foo; rescue; bar; rescue; baz; end').
           must_be_parsed_as s(:rescue,
                               s(:call, nil, :foo),
                               s(:resbody,
@@ -235,7 +235,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works for a block with rescue and else' do
-        'begin; foo; rescue; bar; else; baz; end'.
+        _('begin; foo; rescue; bar; else; baz; end').
           must_be_parsed_as s(:rescue,
                               s(:call, nil, :foo),
                               s(:resbody,
@@ -245,7 +245,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works for a block with only else' do
-        'begin; foo; else; bar; end'.
+        _('begin; foo; else; bar; end').
           must_be_parsed_as s(:block,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar))
@@ -254,7 +254,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for the rescue statement' do
       it 'works with assignment to an error variable' do
-        'begin; foo; rescue => bar; baz; end'.
+        _('begin; foo; rescue => bar; baz; end').
           must_be_parsed_as s(:rescue,
                               s(:call, nil, :foo),
                               s(:resbody,
@@ -264,7 +264,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with assignment of the exception to an instance variable' do
-        'begin; foo; rescue => @bar; baz; end'.
+        _('begin; foo; rescue => @bar; baz; end').
           must_be_parsed_as s(:rescue,
                               s(:call, nil, :foo),
                               s(:resbody,
@@ -274,13 +274,13 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with empty main and rescue bodies' do
-        'begin; rescue; end'.
+        _('begin; rescue; end').
           must_be_parsed_as s(:rescue,
                               s(:resbody, s(:array), nil))
       end
 
       it 'works with single statement main and rescue bodies' do
-        'begin; foo; rescue; bar; end'.
+        _('begin; foo; rescue; bar; end').
           must_be_parsed_as s(:rescue,
                               s(:call, nil, :foo),
                               s(:resbody,
@@ -289,7 +289,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with multi-statement main and rescue bodies' do
-        'begin; foo; bar; rescue; baz; qux; end'.
+        _('begin; foo; bar; rescue; baz; qux; end').
           must_be_parsed_as s(:rescue,
                               s(:block,
                                 s(:call, nil, :foo),
@@ -301,7 +301,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with assignment to an error variable' do
-        'begin; foo; rescue => e; bar; end'.
+        _('begin; foo; rescue => e; bar; end').
           must_be_parsed_as s(:rescue,
                               s(:call, nil, :foo),
                               s(:resbody,
@@ -310,7 +310,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with filtering of the exception type' do
-        'begin; foo; rescue Bar; baz; end'.
+        _('begin; foo; rescue Bar; baz; end').
           must_be_parsed_as s(:rescue,
                               s(:call, nil, :foo),
                               s(:resbody,
@@ -319,7 +319,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with filtering of the exception type and assignment to an error variable' do
-        'begin; foo; rescue Bar => e; baz; end'.
+        _('begin; foo; rescue Bar => e; baz; end').
           must_be_parsed_as s(:rescue,
                               s(:call, nil, :foo),
                               s(:resbody,
@@ -330,7 +330,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works rescuing multiple exception types' do
-        'begin; foo; rescue Bar, Baz; qux; end'.
+        _('begin; foo; rescue Bar, Baz; qux; end').
           must_be_parsed_as s(:rescue,
                               s(:call, nil, :foo),
                               s(:resbody,
@@ -339,7 +339,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works rescuing a splatted list of exception types' do
-        'begin; foo; rescue *bar; baz; end'.
+        _('begin; foo; rescue *bar; baz; end').
           must_be_parsed_as s(:rescue,
                               s(:call, nil, :foo),
                               s(:resbody,
@@ -348,7 +348,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works rescuing a complex list of exception types' do
-        'begin; foo; rescue *bar, Baz; qux; end'.
+        _('begin; foo; rescue *bar, Baz; qux; end').
           must_be_parsed_as s(:rescue,
                               s(:call, nil, :foo),
                               s(:resbody,
@@ -359,7 +359,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a nested begin..end block' do
-        'begin; foo; rescue; begin; bar; end; end'.
+        _('begin; foo; rescue; begin; bar; end; end').
           must_be_parsed_as s(:rescue,
                               s(:call, nil, :foo),
                               s(:resbody, s(:array),
@@ -367,7 +367,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works in a plain method body' do
-        'def foo; bar; rescue; baz; end'.
+        _('def foo; bar; rescue; baz; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args),
@@ -379,7 +379,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works in a method body inside begin..end with rescue' do
-        'def foo; bar; begin; baz; rescue; qux; end; quuz; end'.
+        _('def foo; bar; begin; baz; rescue; qux; end; quuz; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args),
@@ -391,7 +391,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works in a method body inside begin..end without rescue' do
-        'def foo; bar; begin; baz; qux; end; quuz; end'.
+        _('def foo; bar; begin; baz; qux; end; quuz; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args),
@@ -403,7 +403,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works in a method body fully inside begin..end' do
-        'def foo; begin; bar; baz; end; end'.
+        _('def foo; begin; bar; baz; end; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args),
@@ -414,7 +414,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for the postfix rescue modifier' do
       it 'works in the basic case' do
-        'foo rescue bar'.
+        _('foo rescue bar').
           must_be_parsed_as s(:rescue,
                               s(:call, nil, :foo),
                               s(:resbody,
@@ -423,7 +423,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works when the fallback value is a keyword' do
-        'foo rescue next'.
+        _('foo rescue next').
           must_be_parsed_as s(:rescue,
                               s(:call, nil, :foo),
                               s(:resbody,
@@ -434,14 +434,14 @@ describe RipperRubyParser::Parser do
 
     describe 'for the ensure statement' do
       it 'works with single statement main and ensure bodies' do
-        'begin; foo; ensure; bar; end'.
+        _('begin; foo; ensure; bar; end').
           must_be_parsed_as s(:ensure,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar))
       end
 
       it 'works with multi-statement main and ensure bodies' do
-        'begin; foo; bar; ensure; baz; qux; end'.
+        _('begin; foo; bar; ensure; baz; qux; end').
           must_be_parsed_as s(:ensure,
                               s(:block,
                                 s(:call, nil, :foo),
@@ -452,7 +452,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works together with rescue' do
-        'begin; foo; rescue; bar; ensure; baz; end'.
+        _('begin; foo; rescue; bar; ensure; baz; end').
           must_be_parsed_as s(:ensure,
                               s(:rescue,
                                 s(:call, nil, :foo),
@@ -463,14 +463,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with empty main and ensure bodies' do
-        'begin; ensure; end'.
+        _('begin; ensure; end').
           must_be_parsed_as s(:ensure, s(:nil))
       end
     end
 
     describe 'for the next statement' do
       it 'works with no arguments' do
-        'foo do; next; end'.
+        _('foo do; next; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -478,7 +478,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with one argument' do
-        'foo do; next bar; end'.
+        _('foo do; next bar; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -486,7 +486,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a splat argument' do
-        'foo do; next *bar; end'.
+        _('foo do; next *bar; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -497,7 +497,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with several arguments' do
-        'foo do; next bar, baz; end'.
+        _('foo do; next bar, baz; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -508,7 +508,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a function call with parentheses' do
-        'foo do; next foo(bar); end'.
+        _('foo do; next foo(bar); end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -518,7 +518,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a function call without parentheses' do
-        'foo do; next foo bar; end'.
+        _('foo do; next foo bar; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -530,7 +530,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for the break statement' do
       it 'works with break with no arguments' do
-        'foo do; break; end'.
+        _('foo do; break; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -538,7 +538,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with break with one argument' do
-        'foo do; break bar; end'.
+        _('foo do; break bar; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -546,7 +546,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a splat argument' do
-        'foo do; break *bar; end'.
+        _('foo do; break *bar; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -557,7 +557,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with break with several arguments' do
-        'foo do; break bar, baz; end'.
+        _('foo do; break bar, baz; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -568,7 +568,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with break with a function call with parentheses' do
-        'foo do; break foo(bar); end'.
+        _('foo do; break foo(bar); end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -578,7 +578,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with break with a function call without parentheses' do
-        'foo do; break foo bar; end'.
+        _('foo do; break foo bar; end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
                               0,
@@ -590,7 +590,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for lists of consecutive statments' do
       it 'removes extra blocks for grouped statements at the start of the list' do
-        '(foo; bar); baz'.
+        _('(foo; bar); baz').
           must_be_parsed_as s(:block,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -598,7 +598,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'keeps extra blocks for grouped statements at the end of the list' do
-        'foo; (bar; baz)'.
+        _('foo; (bar; baz)').
           must_be_parsed_as s(:block,
                               s(:call, nil, :foo),
                               s(:block,
@@ -609,7 +609,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for stabby lambda' do
       it 'works in the simple case' do
-        '->(foo) { bar }'.
+        _('->(foo) { bar }').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :lambda),
                               s(:args, :foo),
@@ -617,7 +617,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works in the simple case without parentheses' do
-        '-> foo { bar }'.
+        _('-> foo { bar }').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :lambda),
                               s(:args, :foo),
@@ -625,7 +625,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works when there are zero arguments' do
-        '->() { bar }'.
+        _('->() { bar }').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :lambda),
                               s(:args),
@@ -633,7 +633,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works when there are no arguments' do
-        '-> { bar }'.
+        _('-> { bar }').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :lambda),
                               0,
@@ -641,14 +641,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works when there are no statements in the body' do
-        '->(foo) { }'.
+        _('->(foo) { }').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :lambda),
                               s(:args, :foo))
       end
 
       it 'works when there are several statements in the body' do
-        '->(foo) { bar; baz }'.
+        _('->(foo) { bar; baz }').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :lambda),
                               s(:args, :foo),

--- a/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
@@ -6,7 +6,7 @@ describe RipperRubyParser::Parser do
   describe '#parse' do
     describe 'for regular if' do
       it 'works with a single statement' do
-        'if foo; bar; end'.
+        _('if foo; bar; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -14,7 +14,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with multiple statements' do
-        'if foo; bar; baz; end'.
+        _('if foo; bar; baz; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:block,
@@ -24,7 +24,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with zero statements' do
-        'if foo; end'.
+        _('if foo; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               nil,
@@ -32,7 +32,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a begin..end block' do
-        'if foo; begin; bar; end; end'.
+        _('if foo; begin; bar; end; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -40,7 +40,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with an else clause' do
-        'if foo; bar; else; baz; end'.
+        _('if foo; bar; else; baz; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -48,7 +48,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with an empty main clause' do
-        'if foo; else; bar; end'.
+        _('if foo; else; bar; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               nil,
@@ -56,7 +56,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with an empty else clause' do
-        'if foo; bar; else; end'.
+        _('if foo; bar; else; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -64,7 +64,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles a negative condition correctly' do
-        'if not foo; bar; end'.
+        _('if not foo; bar; end').
           must_be_parsed_as s(:if,
                               s(:call, s(:call, nil, :foo), :!),
                               s(:call, nil, :bar),
@@ -72,7 +72,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles bare integer literal in condition' do
-        'if 1; bar; end'.
+        _('if 1; bar; end').
           must_be_parsed_as s(:if,
                               s(:lit, 1),
                               s(:call, nil, :bar),
@@ -80,7 +80,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles bare regex literal in condition' do
-        'if /foo/; bar; end'.
+        _('if /foo/; bar; end').
           must_be_parsed_as s(:if,
                               s(:match, s(:lit, /foo/)),
                               s(:call, nil, :bar),
@@ -88,7 +88,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles interpolated regex in condition' do
-        'if /#{foo}/; bar; end'.
+        _('if /#{foo}/; bar; end').
           must_be_parsed_as s(:if,
                               s(:dregx, '', s(:evstr, s(:call, nil, :foo))),
                               s(:call, nil, :bar),
@@ -96,7 +96,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles block conditions' do
-        'if (foo; bar); baz; end'.
+        _('if (foo; bar); baz; end').
           must_be_parsed_as s(:if,
                               s(:block, s(:call, nil, :foo), s(:call, nil, :bar)),
                               s(:call, nil, :baz),
@@ -104,7 +104,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'converts :dot2 to :flip2' do
-        'if foo..bar; baz; end'.
+        _('if foo..bar; baz; end').
           must_be_parsed_as s(:if,
                               s(:flip2, s(:call, nil, :foo), s(:call, nil, :bar)),
                               s(:call, nil, :baz),
@@ -112,7 +112,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'converts :dot3 to :flip3' do
-        'if foo...bar; baz; end'.
+        _('if foo...bar; baz; end').
           must_be_parsed_as s(:if,
                               s(:flip3, s(:call, nil, :foo), s(:call, nil, :bar)),
                               s(:call, nil, :baz),
@@ -120,7 +120,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles negative match operator' do
-        'if foo !~ bar; baz; else; qux; end'.
+        _('if foo !~ bar; baz; else; qux; end').
           must_be_parsed_as s(:if,
                               s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
                               s(:call, nil, :qux),
@@ -128,14 +128,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'cleans up begin..end block in condition' do
-        'if begin foo end; bar; end'.
+        _('if begin foo end; bar; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar), nil)
       end
 
       it 'handles special conditions inside begin..end block' do
-        'if begin foo..bar end; baz; end'.
+        _('if begin foo..bar end; baz; end').
           must_be_parsed_as s(:if,
                               s(:flip2, s(:call, nil, :foo), s(:call, nil, :bar)),
                               s(:call, nil, :baz),
@@ -143,7 +143,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with assignment in the condition' do
-        'if foo = bar; baz; end'.
+        _('if foo = bar; baz; end').
           must_be_parsed_as s(:if,
                               s(:lasgn, :foo,
                                 s(:call, nil, :bar)),
@@ -151,7 +151,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with bracketed assignment in the condition' do
-        'if (foo = bar); baz; end'.
+        _('if (foo = bar); baz; end').
           must_be_parsed_as s(:if,
                               s(:lasgn, :foo,
                                 s(:call, nil, :bar)),
@@ -161,7 +161,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for postfix if' do
       it 'works with a simple condition' do
-        'foo if bar'.
+        _('foo if bar').
           must_be_parsed_as s(:if,
                               s(:call, nil, :bar),
                               s(:call, nil, :foo),
@@ -169,7 +169,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles negative conditions' do
-        'foo if not bar'.
+        _('foo if not bar').
           must_be_parsed_as s(:if,
                               s(:call, s(:call, nil, :bar), :!),
                               s(:call, nil, :foo),
@@ -177,7 +177,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles bare regex literal in condition' do
-        'foo if /bar/'.
+        _('foo if /bar/').
           must_be_parsed_as s(:if,
                               s(:match, s(:lit, /bar/)),
                               s(:call, nil, :foo),
@@ -185,7 +185,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles interpolated regex in condition' do
-        'foo if /#{bar}/'.
+        _('foo if /#{bar}/').
           must_be_parsed_as s(:if,
                               s(:dregx, '', s(:evstr, s(:call, nil, :bar))),
                               s(:call, nil, :foo),
@@ -193,7 +193,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles negative match operator' do
-        'baz if foo !~ bar'.
+        _('baz if foo !~ bar').
           must_be_parsed_as s(:if,
                               s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
                               nil,
@@ -201,7 +201,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'cleans up begin..end block in condition' do
-        'foo if begin bar end'.
+        _('foo if begin bar end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :bar),
                               s(:call, nil, :foo), nil)
@@ -210,7 +210,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for regular unless' do
       it 'works with a single statement' do
-        'unless bar; foo; end'.
+        _('unless bar; foo; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :bar),
                               nil,
@@ -218,7 +218,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with multiple statements' do
-        'unless foo; bar; baz; end'.
+        _('unless foo; bar; baz; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               nil,
@@ -228,7 +228,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with zero statements' do
-        'unless foo; end'.
+        _('unless foo; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               nil,
@@ -236,7 +236,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with an else clause' do
-        'unless foo; bar; else; baz; end'.
+        _('unless foo; bar; else; baz; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :baz),
@@ -244,7 +244,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with an empty main clause' do
-        'unless foo; else; bar; end'.
+        _('unless foo; else; bar; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -252,7 +252,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with an empty else block' do
-        'unless foo; bar; else; end'.
+        _('unless foo; bar; else; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               nil,
@@ -260,7 +260,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles bare regex literal in condition' do
-        'unless /foo/; bar; end'.
+        _('unless /foo/; bar; end').
           must_be_parsed_as s(:if,
                               s(:match, s(:lit, /foo/)),
                               nil,
@@ -268,7 +268,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles interpolated regex in condition' do
-        'unless /#{foo}/; bar; end'.
+        _('unless /#{foo}/; bar; end').
           must_be_parsed_as s(:if,
                               s(:dregx, '', s(:evstr, s(:call, nil, :foo))),
                               nil,
@@ -276,7 +276,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles negative match operator' do
-        'unless foo !~ bar; baz; else; qux; end'.
+        _('unless foo !~ bar; baz; else; qux; end').
           must_be_parsed_as s(:if,
                               s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
                               s(:call, nil, :baz),
@@ -286,7 +286,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for postfix unless' do
       it 'works with a simple condition' do
-        'foo unless bar'.
+        _('foo unless bar').
           must_be_parsed_as s(:if,
                               s(:call, nil, :bar),
                               nil,
@@ -294,7 +294,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles bare regex literal in condition' do
-        'foo unless /bar/'.
+        _('foo unless /bar/').
           must_be_parsed_as s(:if,
                               s(:match, s(:lit, /bar/)),
                               nil,
@@ -302,7 +302,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles interpolated regex in condition' do
-        'foo unless /#{bar}/'.
+        _('foo unless /#{bar}/').
           must_be_parsed_as s(:if,
                               s(:dregx, '', s(:evstr, s(:call, nil, :bar))),
                               nil,
@@ -310,7 +310,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles negative match operator' do
-        'baz unless foo !~ bar'.
+        _('baz unless foo !~ bar').
           must_be_parsed_as s(:if,
                               s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
                               s(:call, nil, :baz),
@@ -320,7 +320,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for elsif' do
       it 'works with a single statement' do
-        'if foo; bar; elsif baz; qux; end'.
+        _('if foo; bar; elsif baz; qux; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -331,7 +331,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with an empty consequesnt' do
-        'if foo; bar; elsif baz; end'.
+        _('if foo; bar; elsif baz; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -342,7 +342,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with an else' do
-        'if foo; bar; elsif baz; qux; else; quuz; end'.
+        _('if foo; bar; elsif baz; qux; else; quuz; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -353,7 +353,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with an empty else' do
-        'if foo; bar; elsif baz; qux; else; end'.
+        _('if foo; bar; elsif baz; qux; else; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -364,7 +364,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles a negative condition correctly' do
-        'if foo; bar; elsif not baz; qux; end'.
+        _('if foo; bar; elsif not baz; qux; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -374,7 +374,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'does not replace :dot2 with :flip2' do
-        'if foo; bar; elsif baz..qux; quuz; end'.
+        _('if foo; bar; elsif baz..qux; quuz; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -384,7 +384,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'does not rewrite the negative match operator' do
-        'if foo; bar; elsif baz !~ qux; quuz; end'.
+        _('if foo; bar; elsif baz !~ qux; quuz; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -399,7 +399,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'cleans up begin..end block in condition' do
-        'if foo; bar; elsif begin baz end; qux; end'.
+        _('if foo; bar; elsif begin baz end; qux; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -412,7 +412,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for case block' do
       it 'works with a single when clause' do
-        'case foo; when bar; baz; end'.
+        _('case foo; when bar; baz; end').
           must_be_parsed_as s(:case,
                               s(:call, nil, :foo),
                               s(:when,
@@ -422,7 +422,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with multiple when clauses' do
-        'case foo; when bar; baz; when qux; quux; end'.
+        _('case foo; when bar; baz; when qux; quux; end').
           must_be_parsed_as s(:case,
                               s(:call, nil, :foo),
                               s(:when,
@@ -435,7 +435,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with multiple statements in the when block' do
-        'case foo; when bar; baz; qux; end'.
+        _('case foo; when bar; baz; qux; end').
           must_be_parsed_as s(:case,
                               s(:call, nil, :foo),
                               s(:when,
@@ -446,7 +446,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with an else clause' do
-        'case foo; when bar; baz; else; qux; end'.
+        _('case foo; when bar; baz; else; qux; end').
           must_be_parsed_as s(:case,
                               s(:call, nil, :foo),
                               s(:when,
@@ -456,7 +456,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with multiple statements in the else block' do
-        'case foo; when bar; baz; else; qux; quuz end'.
+        _('case foo; when bar; baz; else; qux; quuz end').
           must_be_parsed_as s(:case,
                               s(:call, nil, :foo),
                               s(:when,
@@ -469,7 +469,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with an empty when block' do
-        'case foo; when bar; end'.
+        _('case foo; when bar; end').
           must_be_parsed_as s(:case,
                               s(:call, nil, :foo),
                               s(:when, s(:array, s(:call, nil, :bar)), nil),
@@ -477,7 +477,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with an empty else block' do
-        'case foo; when bar; baz; else; end'.
+        _('case foo; when bar; baz; else; end').
           must_be_parsed_as s(:case,
                               s(:call, nil, :foo),
                               s(:when,
@@ -487,7 +487,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a splat in the when clause' do
-        'case foo; when *bar; baz; end'.
+        _('case foo; when *bar; baz; end').
           must_be_parsed_as s(:case,
                               s(:call, nil, :foo),
                               s(:when,
@@ -498,7 +498,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'cleans up a multi-statement begin..end in the when clause' do
-        'case foo; when bar; begin; baz; qux; end; end'.
+        _('case foo; when bar; begin; baz; qux; end; end').
           must_be_parsed_as s(:case,
                               s(:call, nil, :foo),
                               s(:when,
@@ -509,7 +509,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'cleans up a multi-statement begin..end at start of the when clause' do
-        'case foo; when bar; begin; baz; qux; end; quuz; end'.
+        _('case foo; when bar; begin; baz; qux; end; quuz; end').
           must_be_parsed_as s(:case,
                               s(:call, nil, :foo),
                               s(:when,
@@ -521,7 +521,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'keeps up a multi-statement begin..end in the else clause' do
-        'case foo; when bar; baz; else; begin; qux; quuz; end; end'.
+        _('case foo; when bar; baz; else; begin; qux; quuz; end; end').
           must_be_parsed_as s(:case,
                               s(:call, nil, :foo),
                               s(:when,

--- a/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
@@ -8,70 +8,70 @@ describe RipperRubyParser::Parser do
   describe '#parse' do
     describe 'for regexp literals' do
       it 'works for a simple regex literal' do
-        '/foo/'.
+        _('/foo/').
           must_be_parsed_as s(:lit, /foo/)
       end
 
       it 'works for regex literals with escaped right parenthesis' do
-        '/\\)/'.
+        _('/\\)/').
           must_be_parsed_as s(:lit, /\)/)
       end
 
       it 'works for regex literals with escape sequences' do
-        '/\\)\\n\\\\/'.
+        _('/\\)\\n\\\\/').
           must_be_parsed_as s(:lit, /\)\n\\/)
       end
 
       it 'does not fix encoding' do
-        '/2\302\275/'.
+        _('/2\302\275/').
           must_be_parsed_as s(:lit, /2\302\275/)
       end
 
       it 'works for a regex literal with the multiline flag' do
-        '/foo/m'.
+        _('/foo/m').
           must_be_parsed_as s(:lit, /foo/m)
       end
 
       it 'works for a regex literal with the extended flag' do
-        '/foo/x'.
+        _('/foo/x').
           must_be_parsed_as s(:lit, /foo/x)
       end
 
       it 'works for a regex literal with the ignorecase flag' do
-        '/foo/i'.
+        _('/foo/i').
           must_be_parsed_as s(:lit, /foo/i)
       end
 
       it 'works for a regex literal with a combination of flags' do
-        '/foo/ixmn'.
+        _('/foo/ixmn').
           must_be_parsed_as s(:lit, /foo/mixn)
       end
 
       it 'works with the no-encoding flag' do
-        '/foo/n'.
+        _('/foo/n').
           must_be_parsed_as s(:lit, /foo/n)
       end
 
       it 'works with line continuation' do
-        "/foo\\\nbar/".
+        _("/foo\\\nbar/").
           must_be_parsed_as s(:lit, /foobar/)
       end
 
       describe 'for a %r-delimited regex literal' do
         it 'works for the simple case with escape sequences' do
-          '%r[foo\nbar]'.
+          _('%r[foo\nbar]').
             must_be_parsed_as s(:lit, /foo\nbar/)
         end
 
         it 'works with odd delimiters and escape sequences' do
-          '%r_foo\nbar_'.
+          _('%r_foo\nbar_').
             must_be_parsed_as s(:lit, /foo\nbar/)
         end
       end
 
       describe 'with interpolations' do
         it 'works for a simple interpolation' do
-          '/foo#{bar}baz/'.
+          _('/foo#{bar}baz/').
             must_be_parsed_as s(:dregx,
                                 'foo',
                                 s(:evstr, s(:call, nil, :bar)),
@@ -79,7 +79,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works for a regex literal with flags and interpolation' do
-          '/foo#{bar}/ixm'.
+          _('/foo#{bar}/ixm').
             must_be_parsed_as s(:dregx,
                                 'foo',
                                 s(:evstr, s(:call, nil, :bar)),
@@ -87,7 +87,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works with the no-encoding flag' do
-          '/foo#{bar}/n'.
+          _('/foo#{bar}/n').
             must_be_parsed_as s(:dregx,
                                 'foo',
                                 s(:evstr,
@@ -95,7 +95,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works with the unicode-encoding flag' do
-          '/foo#{bar}/u'.
+          _('/foo#{bar}/u').
             must_be_parsed_as s(:dregx,
                                 'foo',
                                 s(:evstr,
@@ -103,7 +103,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works with unicode flag plus other flag' do
-          '/foo#{bar}/un'.
+          _('/foo#{bar}/un').
             must_be_parsed_as s(:dregx,
                                 'foo',
                                 s(:evstr,
@@ -111,7 +111,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works with the euc-encoding flag' do
-          '/foo#{bar}/e'.
+          _('/foo#{bar}/e').
             must_be_parsed_as s(:dregx,
                                 'foo',
                                 s(:evstr,
@@ -119,7 +119,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works with the sjis-encoding flag' do
-          '/foo#{bar}/s'.
+          _('/foo#{bar}/s').
             must_be_parsed_as s(:dregx,
                                 'foo',
                                 s(:evstr,
@@ -127,14 +127,14 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works for a regex literal with interpolate-once flag' do
-          '/foo#{bar}/o'.
+          _('/foo#{bar}/o').
             must_be_parsed_as s(:dregx_once,
                                 'foo',
                                 s(:evstr, s(:call, nil, :bar)))
         end
 
         it 'works with an empty interpolation' do
-          '/foo#{}bar/'.
+          _('/foo#{}bar/').
             must_be_parsed_as s(:dregx,
                                 'foo',
                                 s(:evstr),
@@ -143,15 +143,15 @@ describe RipperRubyParser::Parser do
 
         describe 'containing just a literal string' do
           it 'performs the interpolation when it is at the end' do
-            '/foo#{"bar"}/'.must_be_parsed_as s(:lit, /foobar/)
+            _('/foo#{"bar"}/').must_be_parsed_as s(:lit, /foobar/)
           end
 
           it 'performs the interpolation when it is in the middle' do
-            '/foo#{"bar"}baz/'.must_be_parsed_as s(:lit, /foobarbaz/)
+            _('/foo#{"bar"}baz/').must_be_parsed_as s(:lit, /foobarbaz/)
           end
 
           it 'performs the interpolation when it is at the start' do
-            '/#{"foo"}bar/'.must_be_parsed_as s(:lit, /foobar/)
+            _('/#{"foo"}bar/').must_be_parsed_as s(:lit, /foobar/)
           end
         end
       end
@@ -159,115 +159,115 @@ describe RipperRubyParser::Parser do
 
     describe 'for string literals' do
       it 'works for empty strings' do
-        "''".
+        _("''").
           must_be_parsed_as s(:str, '')
       end
 
       it 'sets the encoding for literal strings to utf8 even if ascii would do' do
         parser = RipperRubyParser::Parser.new
         result = parser.parse '"foo"'
-        result.must_equal s(:str, 'foo')
-        result[1].encoding.to_s.must_equal 'UTF-8'
+        _(result).must_equal s(:str, 'foo')
+        _(result[1].encoding.to_s).must_equal 'UTF-8'
       end
 
       it 'handles line breaks within double-quoted strings' do
-        "\"foo\nbar\"".
+        _("\"foo\nbar\"").
           must_be_parsed_as s(:str, "foo\nbar")
       end
 
       it 'handles line continuation with double-quoted strings' do
-        "\"foo\\\nbar\"".
+        _("\"foo\\\nbar\"").
           must_be_parsed_as s(:str, 'foobar')
       end
 
       it 'escapes line continuation with double-quoted strings' do
-        "\"foo\\\\\nbar\"".
+        _("\"foo\\\\\nbar\"").
           must_be_parsed_as s(:str, "foo\\\nbar")
       end
 
       describe 'with double-quoted strings with escape sequences' do
         it 'works for strings with escape sequences' do
-          '"\\n"'.
+          _('"\\n"').
             must_be_parsed_as s(:str, "\n")
         end
 
         it 'works for strings with useless escape sequences' do
-          '"F\\OO"'.
+          _('"F\\OO"').
             must_be_parsed_as s(:str, 'FOO')
         end
 
         it 'works for strings with escaped backslashes' do
-          '"\\\\n"'.
+          _('"\\\\n"').
             must_be_parsed_as s(:str, '\\n')
         end
 
         it 'works for a representation of a regex literal with escaped right parenthesis' do
-          '"/\\\\)/"'.
+          _('"/\\\\)/"').
             must_be_parsed_as s(:str, '/\\)/')
         end
 
         it 'works for a uselessly escaped right parenthesis' do
-          '"/\\)/"'.
+          _('"/\\)/"').
             must_be_parsed_as s(:str, '/)/')
         end
 
         it 'works for a string containing escaped quotes' do
-          '"\\""'.
+          _('"\\""').
             must_be_parsed_as s(:str, '"')
         end
 
         it 'works with hex escapes' do
-          '"\\x36"'.must_be_parsed_as s(:str, '6')
-          '"\\x4a"'.must_be_parsed_as s(:str, 'J')
-          '"\\x4A"'.must_be_parsed_as s(:str, 'J')
-          '"\\x3Z"'.must_be_parsed_as s(:str, "\x03Z")
+          _('"\\x36"').must_be_parsed_as s(:str, '6')
+          _('"\\x4a"').must_be_parsed_as s(:str, 'J')
+          _('"\\x4A"').must_be_parsed_as s(:str, 'J')
+          _('"\\x3Z"').must_be_parsed_as s(:str, "\x03Z")
         end
 
         it 'works with single-letter escapes' do
-          '"foo\\abar"'.must_be_parsed_as s(:str, "foo\abar")
-          '"foo\\bbar"'.must_be_parsed_as s(:str, "foo\bbar")
-          '"foo\\ebar"'.must_be_parsed_as s(:str, "foo\ebar")
-          '"foo\\fbar"'.must_be_parsed_as s(:str, "foo\fbar")
-          '"foo\\nbar"'.must_be_parsed_as s(:str, "foo\nbar")
-          '"foo\\rbar"'.must_be_parsed_as s(:str, "foo\rbar")
-          '"foo\\sbar"'.must_be_parsed_as s(:str, "foo\sbar")
-          '"foo\\tbar"'.must_be_parsed_as s(:str, "foo\tbar")
-          '"foo\\vbar"'.must_be_parsed_as s(:str, "foo\vbar")
+          _('"foo\\abar"').must_be_parsed_as s(:str, "foo\abar")
+          _('"foo\\bbar"').must_be_parsed_as s(:str, "foo\bbar")
+          _('"foo\\ebar"').must_be_parsed_as s(:str, "foo\ebar")
+          _('"foo\\fbar"').must_be_parsed_as s(:str, "foo\fbar")
+          _('"foo\\nbar"').must_be_parsed_as s(:str, "foo\nbar")
+          _('"foo\\rbar"').must_be_parsed_as s(:str, "foo\rbar")
+          _('"foo\\sbar"').must_be_parsed_as s(:str, "foo\sbar")
+          _('"foo\\tbar"').must_be_parsed_as s(:str, "foo\tbar")
+          _('"foo\\vbar"').must_be_parsed_as s(:str, "foo\vbar")
         end
 
         it 'works with octal number escapes' do
-          '"foo\\123bar"'.must_be_parsed_as s(:str, "foo\123bar")
-          '"foo\\23bar"'.must_be_parsed_as s(:str, "foo\023bar")
-          '"foo\\3bar"'.must_be_parsed_as s(:str, "foo\003bar")
+          _('"foo\\123bar"').must_be_parsed_as s(:str, "foo\123bar")
+          _('"foo\\23bar"').must_be_parsed_as s(:str, "foo\023bar")
+          _('"foo\\3bar"').must_be_parsed_as s(:str, "foo\003bar")
 
-          '"foo\\118bar"'.must_be_parsed_as s(:str, "foo\0118bar")
-          '"foo\\18bar"'.must_be_parsed_as s(:str, "foo\0018bar")
+          _('"foo\\118bar"').must_be_parsed_as s(:str, "foo\0118bar")
+          _('"foo\\18bar"').must_be_parsed_as s(:str, "foo\0018bar")
         end
 
         it 'works with simple short hand control sequence escapes' do
-          '"foo\\cabar"'.must_be_parsed_as s(:str, "foo\cabar")
-          '"foo\\cZbar"'.must_be_parsed_as s(:str, "foo\cZbar")
+          _('"foo\\cabar"').must_be_parsed_as s(:str, "foo\cabar")
+          _('"foo\\cZbar"').must_be_parsed_as s(:str, "foo\cZbar")
         end
 
         it 'works with simple regular control sequence escapes' do
-          '"foo\\C-abar"'.must_be_parsed_as s(:str, "foo\C-abar")
-          '"foo\\C-Zbar"'.must_be_parsed_as s(:str, "foo\C-Zbar")
+          _('"foo\\C-abar"').must_be_parsed_as s(:str, "foo\C-abar")
+          _('"foo\\C-Zbar"').must_be_parsed_as s(:str, "foo\C-Zbar")
         end
 
         it 'works with unicode escapes' do
-          '"foo\\u273bbar"'.must_be_parsed_as s(:str, 'foo✻bar')
+          _('"foo\\u273bbar"').must_be_parsed_as s(:str, 'foo✻bar')
         end
 
         it 'works with unicode escapes with braces' do
-          '"foo\\u{273b}bar"'.must_be_parsed_as s(:str, 'foo✻bar')
+          _('"foo\\u{273b}bar"').must_be_parsed_as s(:str, 'foo✻bar')
         end
 
         it 'converts to unicode if possible' do
-          '"2\302\275"'.must_be_parsed_as s(:str, '2½')
+          _('"2\302\275"').must_be_parsed_as s(:str, '2½')
         end
 
         it 'does not convert to unicode if result is not valid' do
-          '"2\x82\302\275"'.
+          _('"2\x82\302\275"').
             must_be_parsed_as s(:str,
                                 (+"2\x82\xC2\xBD").force_encoding('ascii-8bit'))
         end
@@ -275,33 +275,33 @@ describe RipperRubyParser::Parser do
 
       describe 'with interpolations containing just a literal string' do
         it 'performs the interpolation when it is at the end' do
-          '"foo#{"bar"}"'.must_be_parsed_as s(:str, 'foobar')
+          _('"foo#{"bar"}"').must_be_parsed_as s(:str, 'foobar')
         end
 
         it 'performs the interpolation when it is in the middle' do
-          '"foo#{"bar"}baz"'.must_be_parsed_as s(:str, 'foobarbaz')
+          _('"foo#{"bar"}baz"').must_be_parsed_as s(:str, 'foobarbaz')
         end
 
         it 'performs the interpolation when it is at the start' do
-          '"#{"foo"}bar"'.must_be_parsed_as s(:str, 'foobar')
+          _('"#{"foo"}bar"').must_be_parsed_as s(:str, 'foobar')
         end
       end
 
       describe 'with interpolations without braces' do
         it 'works for ivars' do
-          "\"foo\#@bar\"".must_be_parsed_as s(:dstr,
+          _("\"foo\#@bar\"").must_be_parsed_as s(:dstr,
                                               'foo',
                                               s(:evstr, s(:ivar, :@bar)))
         end
 
         it 'works for gvars' do
-          "\"foo\#$bar\"".must_be_parsed_as s(:dstr,
+          _("\"foo\#$bar\"").must_be_parsed_as s(:dstr,
                                               'foo',
                                               s(:evstr, s(:gvar, :$bar)))
         end
 
         it 'works for cvars' do
-          "\"foo\#@@bar\"".must_be_parsed_as s(:dstr,
+          _("\"foo\#@@bar\"").must_be_parsed_as s(:dstr,
                                                'foo',
                                                s(:evstr, s(:cvar, :@@bar)))
         end
@@ -309,7 +309,7 @@ describe RipperRubyParser::Parser do
 
       describe 'with interpolations with braces' do
         it 'works for trivial interpolated strings' do
-          '"#{foo}"'.
+          _('"#{foo}"').
             must_be_parsed_as s(:dstr,
                                 '',
                                 s(:evstr,
@@ -317,7 +317,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works for basic interpolated strings' do
-          '"foo#{bar}"'.
+          _('"foo#{bar}"').
             must_be_parsed_as s(:dstr,
                                 'foo',
                                 s(:evstr,
@@ -325,7 +325,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works for strings with several interpolations' do
-          '"foo#{bar}baz#{qux}"'.
+          _('"foo#{bar}baz#{qux}"').
             must_be_parsed_as s(:dstr,
                                 'foo',
                                 s(:evstr, s(:call, nil, :bar)),
@@ -334,7 +334,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'correctly handles two interpolations in a row' do
-          "\"\#{bar}\#{qux}\"".
+          _("\"\#{bar}\#{qux}\"").
             must_be_parsed_as s(:dstr,
                                 '',
                                 s(:evstr, s(:call, nil, :bar)),
@@ -342,7 +342,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works with an empty interpolation' do
-          "\"foo\#{}bar\"".
+          _("\"foo\#{}bar\"").
             must_be_parsed_as s(:dstr,
                                 'foo',
                                 s(:evstr),
@@ -350,14 +350,14 @@ describe RipperRubyParser::Parser do
         end
 
         it 'correctly handles interpolation with __FILE__ before another interpolation' do
-          "\"foo\#{__FILE__}\#{bar}\"".
+          _("\"foo\#{__FILE__}\#{bar}\"").
             must_be_parsed_as s(:dstr,
                                 'foo(string)',
                                 s(:evstr, s(:call, nil, :bar)))
         end
 
         it 'correctly handles interpolation with __FILE__ after another interpolation' do
-          "\"\#{bar}foo\#{__FILE__}\"".
+          _("\"\#{bar}foo\#{__FILE__}\"").
             must_be_parsed_as s(:dstr,
                                 '',
                                 s(:evstr, s(:call, nil, :bar)),
@@ -366,14 +366,14 @@ describe RipperRubyParser::Parser do
         end
 
         it 'correctly handles nested interpolation' do
-          '"foo#{"bar#{baz}"}"'.
+          _('"foo#{"bar#{baz}"}"').
             must_be_parsed_as s(:dstr,
                                 'foobar',
                                 s(:evstr, s(:call, nil, :baz)))
         end
 
         it 'correctly handles consecutive nested interpolation' do
-          '"foo#{"bar#{baz}"}foo#{"bar#{baz}"}"'.
+          _('"foo#{"bar#{baz}"}foo#{"bar#{baz}"}"').
             must_be_parsed_as s(:dstr,
                                 'foobar',
                                 s(:evstr, s(:call, nil, :baz)),
@@ -385,7 +385,7 @@ describe RipperRubyParser::Parser do
 
       describe 'with interpolations and escape sequences' do
         it 'works when interpolations are followed by escape sequences' do
-          '"#{foo}\\n"'.
+          _('"#{foo}\\n"').
             must_be_parsed_as s(:dstr,
                                 '',
                                 s(:evstr, s(:call, nil, :foo)),
@@ -393,7 +393,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'works when interpolations contain a mix of other string-like literals' do
-          '"#{[:foo, \'bar\']}\\n"'.
+          _('"#{[:foo, \'bar\']}\\n"').
             must_be_parsed_as s(:dstr,
                                 '',
                                 s(:evstr, s(:array, s(:lit, :foo), s(:str, 'bar'))),
@@ -401,7 +401,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'converts to unicode after interpolation' do
-          '"#{foo}2\302\275"'.
+          _('"#{foo}2\302\275"').
             must_be_parsed_as s(:dstr,
                                 '',
                                 s(:evstr, s(:call, nil, :foo)),
@@ -409,7 +409,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'convert single null byte to unicode after interpolation' do
-          '"#{foo}\0"'.
+          _('"#{foo}\0"').
             must_be_parsed_as s(:dstr,
                                 '',
                                 s(:evstr, s(:call, nil, :foo)),
@@ -417,7 +417,7 @@ describe RipperRubyParser::Parser do
         end
 
         it 'converts string with null to unicode after interpolation' do
-          '"#{foo}bar\0"'.
+          _('"#{foo}bar\0"').
             must_be_parsed_as s(:dstr,
                                 '',
                                 s(:evstr, s(:call, nil, :foo)),
@@ -427,109 +427,109 @@ describe RipperRubyParser::Parser do
 
       describe 'with single quoted strings' do
         it 'works with escaped single quotes' do
-          "'foo\\'bar'".
+          _("'foo\\'bar'").
             must_be_parsed_as s(:str, "foo'bar")
         end
 
         it 'works with embedded backslashes' do
-          "'foo\\abar'".
+          _("'foo\\abar'").
             must_be_parsed_as s(:str, 'foo\abar')
         end
 
         it 'works with escaped embedded backslashes' do
-          "'foo\\\\abar'".
+          _("'foo\\\\abar'").
             must_be_parsed_as s(:str, 'foo\abar')
         end
 
         it 'works with sequences of backslashes' do
-          "'foo\\\\\\abar'".
+          _("'foo\\\\\\abar'").
             must_be_parsed_as s(:str, 'foo\\\\abar')
         end
 
         it 'does not process line continuation' do
-          "'foo\\\nbar'".
+          _("'foo\\\nbar'").
             must_be_parsed_as s(:str, "foo\\\nbar")
         end
       end
 
       describe 'with %Q-delimited strings' do
         it 'works for the simple case' do
-          '%Q[bar]'.
+          _('%Q[bar]').
             must_be_parsed_as s(:str, 'bar')
         end
 
         it 'works for escape sequences' do
-          '%Q[foo\\nbar]'.
+          _('%Q[foo\\nbar]').
             must_be_parsed_as s(:str, "foo\nbar")
         end
 
         it 'works for multi-line strings' do
-          "%Q[foo\nbar]".
+          _("%Q[foo\nbar]").
             must_be_parsed_as s(:str, "foo\nbar")
         end
 
         it 'handles line continuation' do
-          "%Q[foo\\\nbar]".
+          _("%Q[foo\\\nbar]").
             must_be_parsed_as s(:str, 'foobar')
         end
       end
 
       describe 'with %q-delimited strings' do
         it 'works for the simple case' do
-          '%q[bar]'.
+          _('%q[bar]').
             must_be_parsed_as s(:str, 'bar')
         end
 
         it 'does not handle for escape sequences' do
-          '%q[foo\\nbar]'.
+          _('%q[foo\\nbar]').
             must_be_parsed_as s(:str, 'foo\nbar')
         end
 
         it 'works for multi-line strings' do
-          "%q[foo\nbar]".
+          _("%q[foo\nbar]").
             must_be_parsed_as s(:str, "foo\nbar")
         end
 
         it 'handles line continuation' do
-          "%q[foo\\\nbar]".
+          _("%q[foo\\\nbar]").
             must_be_parsed_as s(:str, "foo\\\nbar")
         end
       end
 
       describe 'with %-delimited strings' do
         it 'works for the simple case' do
-          '%(bar)'.
+          _('%(bar)').
             must_be_parsed_as s(:str, 'bar')
         end
 
         it 'works for escape sequences' do
-          '%(foo\nbar)'.
+          _('%(foo\nbar)').
             must_be_parsed_as s(:str, "foo\nbar")
         end
 
         it 'works for multiple lines' do
-          "%(foo\nbar)".
+          _("%(foo\nbar)").
             must_be_parsed_as s(:str, "foo\nbar")
         end
 
         it 'works with line continuations' do
-          "%(foo\\\nbar)".
+          _("%(foo\\\nbar)").
             must_be_parsed_as s(:str, 'foobar')
         end
 
         it 'works for odd delimiters' do
-          '%!foo\nbar!'.
+          _('%!foo\nbar!').
             must_be_parsed_as s(:str, "foo\nbar")
         end
       end
 
       describe 'with string concatenation' do
         it 'performs the concatenation in the case of two simple literal strings' do
-          '"foo" "bar"'.must_be_parsed_as s(:str, 'foobar')
+          _('"foo" "bar"').must_be_parsed_as s(:str, 'foobar')
         end
 
         it 'performs the concatenation when the right string has interpolations' do
-          "\"foo\" \"bar\#{baz}\"".
+          _("\"foo\" \"bar\#{baz}\"").
             must_be_parsed_as s(:dstr,
                                 'foobar',
                                 s(:evstr, s(:call, nil, :baz)))
@@ -537,7 +537,7 @@ describe RipperRubyParser::Parser do
 
         describe 'when the left string has interpolations' do
           it 'performs the concatenation' do
-            "\"foo\#{bar}\" \"baz\"".
+            _("\"foo\#{bar}\" \"baz\"").
               must_be_parsed_as s(:dstr,
                                   'foo',
                                   s(:evstr, s(:call, nil, :bar)),
@@ -545,7 +545,7 @@ describe RipperRubyParser::Parser do
           end
 
           it 'performs the concatenation with an empty string' do
-            "\"foo\#{bar}\" \"\"".
+            _("\"foo\#{bar}\" \"\"").
               must_be_parsed_as s(:dstr,
                                   'foo',
                                   s(:evstr, s(:call, nil, :bar)),
@@ -555,7 +555,7 @@ describe RipperRubyParser::Parser do
 
         describe 'when both strings have interpolations' do
           it 'performs the concatenation' do
-            "\"foo\#{bar}\" \"baz\#{qux}\"".
+            _("\"foo\#{bar}\" \"baz\#{qux}\"").
               must_be_parsed_as s(:dstr,
                                   'foo',
                                   s(:evstr, s(:call, nil, :bar)),
@@ -564,7 +564,7 @@ describe RipperRubyParser::Parser do
           end
 
           it 'removes empty substrings from the concatenation' do
-            "\"foo\#{bar}\" \"\#{qux}\"".
+            _("\"foo\#{bar}\" \"\#{qux}\"").
               must_be_parsed_as s(:dstr,
                                   'foo',
                                   s(:evstr, s(:call, nil, :bar)),
@@ -575,86 +575,86 @@ describe RipperRubyParser::Parser do
 
       describe 'for heredocs' do
         it 'works for the simple case' do
-          "<<FOO\nbar\nFOO".
+          _("<<FOO\nbar\nFOO").
             must_be_parsed_as s(:str, "bar\n")
         end
 
         it 'works with multiple lines' do
-          "<<FOO\nbar\nbaz\nFOO".
+          _("<<FOO\nbar\nbaz\nFOO").
             must_be_parsed_as s(:str, "bar\nbaz\n")
         end
 
         it 'works for the indentable case' do
-          "<<-FOO\n  bar\n  FOO".
+          _("<<-FOO\n  bar\n  FOO").
             must_be_parsed_as s(:str, "  bar\n")
         end
 
         it 'works for the automatically outdenting case' do
-          "  <<~FOO\n  bar\n  FOO".
+          _("  <<~FOO\n  bar\n  FOO").
             must_be_parsed_as s(:str, "bar\n")
         end
 
         it 'works for escape sequences' do
-          "<<FOO\nbar\\tbaz\nFOO".
+          _("<<FOO\nbar\\tbaz\nFOO").
             must_be_parsed_as s(:str, "bar\tbaz\n")
         end
 
         it 'converts \r to carriage returns' do
-          "<<FOO\nbar\\rbaz\\r\nFOO".
+          _("<<FOO\nbar\\rbaz\\r\nFOO").
             must_be_parsed_as s(:str, "bar\rbaz\r\n")
         end
 
         it 'does not unescape with single quoted version' do
-          "<<'FOO'\nbar\\tbaz\nFOO".
+          _("<<'FOO'\nbar\\tbaz\nFOO").
             must_be_parsed_as s(:str, "bar\\tbaz\n")
         end
 
         it 'works with multiple lines with the single quoted version' do
-          "<<'FOO'\nbar\nbaz\nFOO".
+          _("<<'FOO'\nbar\nbaz\nFOO").
             must_be_parsed_as s(:str, "bar\nbaz\n")
         end
 
         it 'does not unescape with indentable single quoted version' do
-          "<<-'FOO'\n  bar\\tbaz\n  FOO".
+          _("<<-'FOO'\n  bar\\tbaz\n  FOO").
             must_be_parsed_as s(:str, "  bar\\tbaz\n")
         end
 
         it 'does not unescape the automatically outdenting single quoted version' do
-          "<<~'FOO'\n  bar\\tbaz\n  FOO".
+          _("<<~'FOO'\n  bar\\tbaz\n  FOO").
             must_be_parsed_as s(:str, "bar\\tbaz\n")
         end
 
         it 'handles line continuation' do
-          "<<FOO\nbar\\\nbaz\nFOO".
+          _("<<FOO\nbar\\\nbaz\nFOO").
             must_be_parsed_as s(:str, "barbaz\n")
         end
 
         it 'escapes line continuation' do
-          "<<FOO\nbar\\\\\nbaz\nFOO".
+          _("<<FOO\nbar\\\\\nbaz\nFOO").
             must_be_parsed_as s(:str, "bar\\\nbaz\n")
         end
 
         it 'converts to unicode' do
-          "<<FOO\n2\\302\\275\nFOO".
+          _("<<FOO\n2\\302\\275\nFOO").
             must_be_parsed_as s(:str, "2½\n")
         end
 
         it 'handles interpolation' do
-          "<<FOO\n\#{bar}\nFOO".
+          _("<<FOO\n\#{bar}\nFOO").
             must_be_parsed_as s(:dstr, '',
                                 s(:evstr, s(:call, nil, :bar)),
                                 s(:str, "\n"))
         end
 
         it 'handles line continuation after interpolation' do
-          "<<FOO\n\#{bar}\nbaz\\\nqux\nFOO".
+          _("<<FOO\n\#{bar}\nbaz\\\nqux\nFOO").
             must_be_parsed_as s(:dstr, '',
                                 s(:evstr, s(:call, nil, :bar)),
                                 s(:str, "\nbazqux\n"))
         end
 
         it 'handles line continuation after interpolation for the indentable case' do
-          "<<-FOO\n\#{bar}\nbaz\\\nqux\nFOO".
+          _("<<-FOO\n\#{bar}\nbaz\\\nqux\nFOO").
             must_be_parsed_as s(:dstr, '',
                                 s(:evstr, s(:call, nil, :bar)),
                                 s(:str, "\nbazqux\n"))
@@ -664,39 +664,39 @@ describe RipperRubyParser::Parser do
 
     describe 'for word list literals with %w delimiter' do
       it 'works for the simple case' do
-        '%w(foo bar)'.
+        _('%w(foo bar)').
           must_be_parsed_as s(:array, s(:str, 'foo'), s(:str, 'bar'))
       end
 
       it 'does not perform interpolation' do
-        '%w(foo\\nbar baz)'.
+        _('%w(foo\\nbar baz)').
           must_be_parsed_as s(:array, s(:str, 'foo\\nbar'), s(:str, 'baz'))
       end
 
       it 'handles line continuation' do
-        "%w(foo\\\nbar baz)".
+        _("%w(foo\\\nbar baz)").
           must_be_parsed_as s(:array, s(:str, "foo\nbar"), s(:str, 'baz'))
       end
 
       it 'handles escaped spaces' do
-        '%w(foo bar\ baz)'.
+        _('%w(foo bar\ baz)').
           must_be_parsed_as s(:array, s(:str, 'foo'), s(:str, 'bar baz'))
       end
     end
 
     describe 'for word list literals with %W delimiter' do
       it 'works for the simple case' do
-        '%W(foo bar)'.
+        _('%W(foo bar)').
           must_be_parsed_as s(:array, s(:str, 'foo'), s(:str, 'bar'))
       end
 
       it 'handles escaped spaces' do
-        '%W(foo bar\ baz)'.
+        _('%W(foo bar\ baz)').
           must_be_parsed_as s(:array, s(:str, 'foo'), s(:str, 'bar baz'))
       end
 
       it 'correctly handles interpolation' do
-        "%W(foo \#{bar} baz)".
+        _("%W(foo \#{bar} baz)").
           must_be_parsed_as  s(:array,
                                s(:str, 'foo'),
                                s(:dstr, '', s(:evstr, s(:call, nil, :bar))),
@@ -704,7 +704,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'correctly handles braceless interpolation' do
-        "%W(foo \#@bar baz)".
+        _("%W(foo \#@bar baz)").
           must_be_parsed_as  s(:array,
                                s(:str, 'foo'),
                                s(:dstr, '', s(:evstr, s(:ivar, :@bar))),
@@ -712,7 +712,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'correctly handles in-word interpolation' do
-        "%W(foo \#{bar}baz)".
+        _("%W(foo \#{bar}baz)").
           must_be_parsed_as s(:array,
                               s(:str, 'foo'),
                               s(:dstr,
@@ -722,25 +722,25 @@ describe RipperRubyParser::Parser do
       end
 
       it 'correctly handles escape sequences' do
-        '%W(foo\nbar baz)'.
+        _('%W(foo\nbar baz)').
           must_be_parsed_as s(:array,
                               s(:str, "foo\nbar"),
                               s(:str, 'baz'))
       end
 
       it 'converts to unicode if possible' do
-        '%W(2\302\275)'.must_be_parsed_as s(:array, s(:str, '2½'))
+        _('%W(2\302\275)').must_be_parsed_as s(:array, s(:str, '2½'))
       end
 
       it 'correctly handles line continuation' do
-        "%W(foo\\\nbar baz)".
+        _("%W(foo\\\nbar baz)").
           must_be_parsed_as s(:array,
                               s(:str, "foo\nbar"),
                               s(:str, 'baz'))
       end
 
       it 'correctly handles multiple lines' do
-        "%W(foo\nbar baz)".
+        _("%W(foo\nbar baz)").
           must_be_parsed_as s(:array,
                               s(:str, 'foo'),
                               s(:str, 'bar'),
@@ -750,36 +750,36 @@ describe RipperRubyParser::Parser do
 
     describe 'for symbol list literals with %i delimiter' do
       it 'works for the simple case' do
-        '%i(foo bar)'.
+        _('%i(foo bar)').
           must_be_parsed_as s(:array, s(:lit, :foo), s(:lit, :bar))
       end
 
       it 'does not perform interpolation' do
-        '%i(foo\\nbar baz)'.
+        _('%i(foo\\nbar baz)').
           must_be_parsed_as s(:array, s(:lit, :"foo\\nbar"), s(:lit, :baz))
       end
 
       it 'handles line continuation' do
-        "%i(foo\\\nbar baz)".
+        _("%i(foo\\\nbar baz)").
           must_be_parsed_as s(:array, s(:lit, :"foo\nbar"), s(:lit, :baz))
       end
     end
 
     describe 'for symbol list literals with %I delimiter' do
       it 'works for the simple case' do
-        '%I(foo bar)'.
+        _('%I(foo bar)').
           must_be_parsed_as s(:array, s(:lit, :foo), s(:lit, :bar))
       end
 
       it 'correctly handles escape sequences' do
-        '%I(foo\nbar baz)'.
+        _('%I(foo\nbar baz)').
           must_be_parsed_as s(:array,
                               s(:lit, :"foo\nbar"),
                               s(:lit, :baz))
       end
 
       it 'correctly handles interpolation' do
-        "%I(foo \#{bar} baz)".
+        _("%I(foo \#{bar} baz)").
           must_be_parsed_as s(:array,
                               s(:lit, :foo),
                               s(:dsym, '', s(:evstr, s(:call, nil, :bar))),
@@ -787,7 +787,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'correctly handles in-word interpolation' do
-        "%I(foo \#{bar}baz)".
+        _("%I(foo \#{bar}baz)").
           must_be_parsed_as s(:array,
                               s(:lit, :foo),
                               s(:dsym,
@@ -797,14 +797,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'correctly handles line continuation' do
-        "%I(foo\\\nbar baz)".
+        _("%I(foo\\\nbar baz)").
           must_be_parsed_as s(:array,
                               s(:lit, :"foo\nbar"),
                               s(:lit, :baz))
       end
 
       it 'correctly handles multiple lines' do
-        "%I(foo\nbar baz)".
+        _("%I(foo\nbar baz)").
           must_be_parsed_as s(:array,
                               s(:lit, :foo),
                               s(:lit, :bar),
@@ -814,200 +814,200 @@ describe RipperRubyParser::Parser do
 
     describe 'for character literals' do
       it 'works for simple character literals' do
-        '?a'.
+        _('?a').
           must_be_parsed_as s(:str, 'a')
       end
 
       it 'works for escaped character literals' do
-        '?\\n'.
+        _('?\\n').
           must_be_parsed_as s(:str, "\n")
       end
 
       it 'works for escaped character literals with ctrl' do
-        '?\\C-a'.
+        _('?\\C-a').
           must_be_parsed_as s(:str, "\u0001")
       end
 
       it 'works for escaped character literals with meta' do
-        '?\\M-a'.
+        _('?\\M-a').
           must_be_parsed_as s(:str, (+"\xE1").force_encoding('ascii-8bit'))
       end
 
       it 'works for escaped character literals with meta plus shorthand ctrl' do
-        '?\\M-\\ca'.
+        _('?\\M-\\ca').
           must_be_parsed_as s(:str, (+"\x81").force_encoding('ascii-8bit'))
       end
 
       it 'works for escaped character literals with shorthand ctrl plus meta' do
-        '?\\c\\M-a'.
+        _('?\\c\\M-a').
           must_be_parsed_as s(:str, (+"\x81").force_encoding('ascii-8bit'))
       end
 
       it 'works for escaped character literals with meta plus ctrl' do
-        '?\\M-\\C-a'.
+        _('?\\M-\\C-a').
           must_be_parsed_as s(:str, (+"\x81").force_encoding('ascii-8bit'))
       end
 
       it 'works for escaped character literals with ctrl plus meta' do
-        '?\\C-\\M-a'.
+        _('?\\C-\\M-a').
           must_be_parsed_as s(:str, (+"\x81").force_encoding('ascii-8bit'))
       end
     end
 
     describe 'for symbol literals' do
       it 'works for simple symbols' do
-        ':foo'.
+        _(':foo').
           must_be_parsed_as s(:lit, :foo)
       end
 
       it 'works for symbols that look like instance variable names' do
-        ':@foo'.
+        _(':@foo').
           must_be_parsed_as s(:lit, :@foo)
       end
 
       it 'works for symbols that look like class names' do
-        ':Foo'.
+        _(':Foo').
           must_be_parsed_as s(:lit, :Foo)
       end
 
       it 'works for symbols that look like keywords' do
-        ':class'.must_be_parsed_as s(:lit, :class)
+        _(':class').must_be_parsed_as s(:lit, :class)
       end
 
       it 'works for :__LINE__' do
-        ':__LINE__'.
+        _(':__LINE__').
           must_be_parsed_as s(:lit, :__LINE__)
       end
 
       it 'works for :__FILE__' do
-        ':__FILE__'.
+        _(':__FILE__').
           must_be_parsed_as s(:lit, :__FILE__)
       end
 
       it 'works for a backtick symbol' do
-        ':`'.must_be_parsed_as s(:lit, :`)
+        _(':`').must_be_parsed_as s(:lit, :`)
       end
 
       it 'works for simple dsyms' do
-        ':"foo"'.
+        _(':"foo"').
           must_be_parsed_as s(:lit, :foo)
       end
 
       it 'works for dsyms with interpolations' do
-        ':"foo#{bar}"'.
+        _(':"foo#{bar}"').
           must_be_parsed_as s(:dsym,
                               'foo',
                               s(:evstr, s(:call, nil, :bar)))
       end
 
       it 'works for dsyms with interpolations at the start' do
-        ':"#{bar}"'.
+        _(':"#{bar}"').
           must_be_parsed_as s(:dsym,
                               '',
                               s(:evstr, s(:call, nil, :bar)))
       end
 
       it 'works for dsyms with escape sequences' do
-        ':"foo\nbar"'.
+        _(':"foo\nbar"').
           must_be_parsed_as s(:lit, :"foo\nbar")
       end
 
       it 'works for dsyms with multiple lines' do
-        ":\"foo\nbar\"".
+        _(":\"foo\nbar\"").
           must_be_parsed_as s(:lit, :"foo\nbar")
       end
 
       it 'works for dsyms with line continuations' do
-        ":\"foo\\\nbar\"".
+        _(":\"foo\\\nbar\"").
           must_be_parsed_as s(:lit, :foobar)
       end
 
       it 'works with single quoted dsyms' do
-        ":'foo'".
+        _(":'foo'").
           must_be_parsed_as s(:lit, :foo)
       end
 
       it 'works with single quoted dsyms with escaped single quotes' do
-        ":'foo\\'bar'".
+        _(":'foo\\'bar'").
           must_be_parsed_as s(:lit, :'foo\'bar')
       end
 
       it 'works with single quoted dsyms with multiple lines' do
-        ":'foo\nbar'".
+        _(":'foo\nbar'").
           must_be_parsed_as s(:lit, :"foo\nbar")
       end
 
       it 'works with single quoted dsyms with line continuations' do
-        ":'foo\\\nbar'".
+        _(":'foo\\\nbar'").
           must_be_parsed_as s(:lit, :"foo\\\nbar")
       end
 
       it 'works with single quoted dsyms with embedded backslashes' do
-        ":'foo\\abar'".
+        _(":'foo\\abar'").
           must_be_parsed_as s(:lit, :"foo\\abar")
       end
 
       it 'works with barewords that need to be interpreted as symbols' do
-        'alias foo bar'.
+        _('alias foo bar').
           must_be_parsed_as s(:alias,
                               s(:lit, :foo), s(:lit, :bar))
       end
 
       it 'assigns a line number to the result' do
         result = parser.parse ':foo'
-        result.line.must_equal 1
+        _(result.line).must_equal 1
       end
     end
 
     describe 'for backtick string literals' do
       it 'works for basic backtick strings' do
-        '`foo`'.
+        _('`foo`').
           must_be_parsed_as s(:xstr, 'foo')
       end
 
       it 'works for interpolated backtick strings' do
-        '`foo#{bar}`'.
+        _('`foo#{bar}`').
           must_be_parsed_as s(:dxstr,
                               'foo',
                               s(:evstr, s(:call, nil, :bar)))
       end
 
       it 'works for backtick strings interpolated at the start' do
-        '`#{foo}`'.
+        _('`#{foo}`').
           must_be_parsed_as s(:dxstr, '',
                               s(:evstr, s(:call, nil, :foo)))
       end
 
       it 'works for backtick strings with escape sequences' do
-        '`foo\\n`'.
+        _('`foo\\n`').
           must_be_parsed_as s(:xstr, "foo\n")
       end
 
       it 'works for backtick strings with multiple lines' do
-        "`foo\nbar`".
+        _("`foo\nbar`").
           must_be_parsed_as s(:xstr, "foo\nbar")
       end
 
       it 'works for backtick strings with line continuations' do
-        "`foo\\\nbar`".
+        _("`foo\\\nbar`").
           must_be_parsed_as s(:xstr, 'foobar')
       end
     end
 
     describe 'for array literals' do
       it 'works for an empty array' do
-        '[]'.
+        _('[]').
           must_be_parsed_as s(:array)
       end
 
       it 'works for a simple case with splat' do
-        '[*foo]'.
+        _('[*foo]').
           must_be_parsed_as s(:array,
                               s(:splat, s(:call, nil, :foo)))
       end
 
       it 'works for a multi-element case with splat' do
-        '[foo, *bar]'.
+        _('[foo, *bar]').
           must_be_parsed_as s(:array,
                               s(:call, nil, :foo),
                               s(:splat, s(:call, nil, :bar)))
@@ -1016,19 +1016,19 @@ describe RipperRubyParser::Parser do
 
     describe 'for hash literals' do
       it 'works for an empty hash' do
-        '{}'.
+        _('{}').
           must_be_parsed_as s(:hash)
       end
 
       it 'works for a hash with one pair' do
-        '{foo => bar}'.
+        _('{foo => bar}').
           must_be_parsed_as s(:hash,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar))
       end
 
       it 'works for a hash with multiple pairs' do
-        '{foo => bar, baz => qux}'.
+        _('{foo => bar, baz => qux}').
           must_be_parsed_as s(:hash,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -1037,7 +1037,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works for a hash with label keys' do
-        '{foo: bar, baz: qux}'.
+        _('{foo: bar, baz: qux}').
           must_be_parsed_as s(:hash,
                               s(:lit, :foo),
                               s(:call, nil, :bar),
@@ -1046,14 +1046,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works for a hash with dynamic label keys' do
-        "{'foo': bar}".
+        _("{'foo': bar}").
           must_be_parsed_as s(:hash,
                               s(:lit, :foo),
                               s(:call, nil, :bar))
       end
 
       it 'works for a hash with splat' do
-        '{foo: bar, baz: qux, **quux}'.
+        _('{foo: bar, baz: qux, **quux}').
           must_be_parsed_as s(:hash,
                               s(:lit, :foo), s(:call, nil, :bar),
                               s(:lit, :baz), s(:call, nil, :qux),
@@ -1063,53 +1063,53 @@ describe RipperRubyParser::Parser do
 
     describe 'for number literals' do
       it 'works for floats' do
-        '3.14'.
+        _('3.14').
           must_be_parsed_as s(:lit, 3.14)
       end
 
       it 'works for octal integer literals' do
-        '0700'.
+        _('0700').
           must_be_parsed_as s(:lit, 448)
       end
 
       it 'handles negative sign for integers' do
-        '-1'.
+        _('-1').
           must_be_parsed_as s(:lit, -1)
       end
 
       it 'handles space after negative sign for integers' do
-        '-1 '.
+        _('-1 ').
           must_be_parsed_as s(:lit, -1)
       end
 
       it 'handles negative sign for floats' do
-        '-3.14'.
+        _('-3.14').
           must_be_parsed_as s(:lit, -3.14)
       end
 
       it 'handles space after negative sign for floats' do
-        '-3.14 '.
+        _('-3.14 ').
           must_be_parsed_as s(:lit, -3.14)
       end
 
       it 'handles positive sign' do
-        '+1'.
+        _('+1').
           must_be_parsed_as s(:lit, 1)
       end
 
       it 'works for rationals' do
-        '1000r'.
+        _('1000r').
           must_be_parsed_as s(:lit, 1000r)
       end
     end
 
     describe 'in extra compatible mode' do
       it 'converts \r to carriage returns in double-quoted strings' do
-        '"foo\\rbar"'.must_be_parsed_as s(:str, "foo\rbar"), extra_compatible: true
+        _('"foo\\rbar"').must_be_parsed_as s(:str, "foo\rbar"), extra_compatible: true
       end
 
       it 'removes \r from heredocs' do
-        "<<FOO\nbar\\rbaz\\r\nFOO".
+        _("<<FOO\nbar\\rbaz\\r\nFOO").
           must_be_parsed_as s(:str, "barbaz\n"), extra_compatible: true
       end
     end

--- a/test/ripper_ruby_parser/sexp_handlers/loops_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/loops_test.rb
@@ -6,84 +6,84 @@ describe RipperRubyParser::Parser do
   describe '#parse' do
     describe 'for the while statement' do
       it 'works with do' do
-        'while foo do; bar; end'.
+        _('while foo do; bar; end').
           must_be_parsed_as s(:while,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar), true)
       end
 
       it 'works without do' do
-        'while foo; bar; end'.
+        _('while foo; bar; end').
           must_be_parsed_as s(:while,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar), true)
       end
 
       it 'works in the single-line postfix case' do
-        'foo while bar'.
+        _('foo while bar').
           must_be_parsed_as s(:while,
                               s(:call, nil, :bar),
                               s(:call, nil, :foo), true)
       end
 
       it 'works in the block postfix case' do
-        'begin; foo; end while bar'.
+        _('begin; foo; end while bar').
           must_be_parsed_as s(:while,
                               s(:call, nil, :bar),
                               s(:call, nil, :foo), false)
       end
 
       it 'handles a negative condition' do
-        'while not foo; bar; end'.
+        _('while not foo; bar; end').
           must_be_parsed_as s(:while,
                               s(:call, s(:call, nil, :foo), :!),
                               s(:call, nil, :bar), true)
       end
 
       it 'handles a negative condition in the postfix case' do
-        'foo while not bar'.
+        _('foo while not bar').
           must_be_parsed_as s(:while,
                               s(:call, s(:call, nil, :bar), :!),
                               s(:call, nil, :foo), true)
       end
 
       it 'converts a negated match condition to :until' do
-        'while foo !~ bar; baz; end'.
+        _('while foo !~ bar; baz; end').
           must_be_parsed_as s(:until,
                               s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
                               s(:call, nil, :baz), true)
       end
 
       it 'converts a negated match condition to :until in the postfix case' do
-        'baz while foo !~ bar'.
+        _('baz while foo !~ bar').
           must_be_parsed_as s(:until,
                               s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
                               s(:call, nil, :baz), true)
       end
 
       it 'cleans up begin..end block in condition' do
-        'while begin foo end; bar; end'.
+        _('while begin foo end; bar; end').
           must_be_parsed_as s(:while,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar), true)
       end
 
       it 'cleans up begin..end block in condition in the postfix case' do
-        'foo while begin bar end'.
+        _('foo while begin bar end').
           must_be_parsed_as s(:while,
                               s(:call, nil, :bar),
                               s(:call, nil, :foo), true)
       end
 
       it 'works with do and an empty body' do
-        'while foo do; end'.
+        _('while foo do; end').
           must_be_parsed_as s(:while,
                               s(:call, nil, :foo),
                               nil, true)
       end
 
       it 'works without do and with an empty body' do
-        'while foo; end'.
+        _('while foo; end').
           must_be_parsed_as s(:while,
                               s(:call, nil, :foo),
                               nil, true)
@@ -92,70 +92,70 @@ describe RipperRubyParser::Parser do
 
     describe 'for the until statement' do
       it 'works in the prefix block case with do' do
-        'until foo do; bar; end'.
+        _('until foo do; bar; end').
           must_be_parsed_as s(:until,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar), true)
       end
 
       it 'works in the prefix block case without do' do
-        'until foo; bar; end'.
+        _('until foo; bar; end').
           must_be_parsed_as s(:until,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar), true)
       end
 
       it 'works in the single-line postfix case' do
-        'foo until bar'.
+        _('foo until bar').
           must_be_parsed_as s(:until,
                               s(:call, nil, :bar),
                               s(:call, nil, :foo), true)
       end
 
       it 'works in the block postfix case' do
-        'begin; foo; end until bar'.
+        _('begin; foo; end until bar').
           must_be_parsed_as s(:until,
                               s(:call, nil, :bar),
                               s(:call, nil, :foo), false)
       end
 
       it 'handles a negative condition' do
-        'until not foo; bar; end'.
+        _('until not foo; bar; end').
           must_be_parsed_as s(:until,
                               s(:call, s(:call, nil, :foo), :!),
                               s(:call, nil, :bar), true)
       end
 
       it 'handles a negative condition in the postfix case' do
-        'foo until not bar'.
+        _('foo until not bar').
           must_be_parsed_as s(:until,
                               s(:call, s(:call, nil, :bar), :!),
                               s(:call, nil, :foo), true)
       end
 
       it 'converts a negated match condition to :while' do
-        'until foo !~ bar; baz; end'.
+        _('until foo !~ bar; baz; end').
           must_be_parsed_as s(:while,
                               s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
                               s(:call, nil, :baz), true)
       end
 
       it 'converts a negated match condition to :while in the postfix case' do
-        'baz until foo !~ bar'.
+        _('baz until foo !~ bar').
           must_be_parsed_as s(:while,
                               s(:call, s(:call, nil, :foo), :=~, s(:call, nil, :bar)),
                               s(:call, nil, :baz), true)
       end
 
       it 'cleans up begin..end block in condition' do
-        'until begin foo end; bar; end'.
+        _('until begin foo end; bar; end').
           must_be_parsed_as s(:until,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar), true)
       end
 
       it 'cleans up begin..end block in condition in the postfix case' do
-        'foo until begin bar end'.
+        _('foo until begin bar end').
           must_be_parsed_as s(:until,
                               s(:call, nil, :bar),
                               s(:call, nil, :foo), true)
@@ -164,7 +164,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for the for statement' do
       it 'works with do' do
-        'for foo in bar do; baz; end'.
+        _('for foo in bar do; baz; end').
           must_be_parsed_as s(:for,
                               s(:call, nil, :bar),
                               s(:lasgn, :foo),
@@ -172,7 +172,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works without do' do
-        'for foo in bar; baz; end'.
+        _('for foo in bar; baz; end').
           must_be_parsed_as s(:for,
                               s(:call, nil, :bar),
                               s(:lasgn, :foo),
@@ -180,14 +180,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with an empty body' do
-        'for foo in bar; end'.
+        _('for foo in bar; end').
           must_be_parsed_as s(:for,
                               s(:call, nil, :bar),
                               s(:lasgn, :foo))
       end
 
       it 'works with explicit multiple assignment' do
-        'for foo, bar in baz; end'.
+        _('for foo, bar in baz; end').
           must_be_parsed_as s(:for,
                               s(:call, nil, :baz),
                               s(:masgn,
@@ -197,7 +197,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with multiple assignment with trailing comma' do
-        'for foo, in bar; end'.
+        _('for foo, in bar; end').
           must_be_parsed_as s(:for,
                               s(:call, nil, :bar),
                               s(:masgn,

--- a/test/ripper_ruby_parser/sexp_handlers/method_calls_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/method_calls_test.rb
@@ -260,7 +260,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
                  s(:vcall, s(:@ident, 'foo', s(1, 0))),
                  :'>.',
                  s(:@ident, 'bar', s(1, 4)))
-        _(-> { processor.process(sexp) }).must_raise
+        _(-> { processor.process(sexp) }).must_raise KeyError
       end
     end
   end

--- a/test/ripper_ruby_parser/sexp_handlers/method_calls_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/method_calls_test.rb
@@ -7,41 +7,41 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
     describe 'for method calls' do
       describe 'without a receiver' do
         it 'works without parentheses' do
-          'foo bar'.
+          _('foo bar').
             must_be_parsed_as s(:call, nil, :foo,
                                 s(:call, nil, :bar))
         end
 
         it 'works with parentheses' do
-          'foo(bar)'.
+          _('foo(bar)').
             must_be_parsed_as s(:call, nil, :foo,
                                 s(:call, nil, :bar))
         end
 
         it 'works with an empty parameter list and no parentheses' do
-          'foo'.
+          _('foo').
             must_be_parsed_as s(:call, nil, :foo)
         end
 
         it 'works with parentheses around an empty parameter list' do
-          'foo()'.
+          _('foo()').
             must_be_parsed_as s(:call, nil, :foo)
         end
 
         it 'works for methods ending in a question mark' do
-          'foo?'.
+          _('foo?').
             must_be_parsed_as s(:call, nil, :foo?)
         end
 
         it 'works with nested calls without parentheses' do
-          'foo bar baz'.
+          _('foo bar baz').
             must_be_parsed_as s(:call, nil, :foo,
                                 s(:call, nil, :bar,
                                   s(:call, nil, :baz)))
         end
 
         it 'works with a non-final splat argument' do
-          'foo(bar, *baz, qux)'.
+          _('foo(bar, *baz, qux)').
             must_be_parsed_as s(:call,
                                 nil,
                                 :foo,
@@ -51,7 +51,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
         end
 
         it 'works with a splat argument followed by several regular arguments' do
-          'foo(bar, *baz, qux, quuz)'.
+          _('foo(bar, *baz, qux, quuz)').
             must_be_parsed_as s(:call,
                                 nil,
                                 :foo,
@@ -62,7 +62,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
         end
 
         it 'works with a named argument' do
-          'foo(bar, baz: qux)'.
+          _('foo(bar, baz: qux)').
             must_be_parsed_as s(:call,
                                 nil,
                                 :foo,
@@ -71,7 +71,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
         end
 
         it 'works with several named arguments' do
-          'foo(bar, baz: qux, quux: quuz)'.
+          _('foo(bar, baz: qux, quux: quuz)').
             must_be_parsed_as s(:call,
                                 nil,
                                 :foo,
@@ -82,7 +82,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
         end
 
         it 'works with a double splat argument' do
-          'foo(bar, **baz)'.
+          _('foo(bar, **baz)').
             must_be_parsed_as s(:call,
                                 nil,
                                 :foo,
@@ -92,7 +92,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
         end
 
         it 'works with a named argument followed by a double splat argument' do
-          'foo(bar, baz: qux, **quuz)'.
+          _('foo(bar, baz: qux, **quuz)').
             must_be_parsed_as s(:call,
                                 nil,
                                 :foo,
@@ -105,7 +105,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
 
       describe 'with a receiver' do
         it 'works without parentheses' do
-          'foo.bar baz'.
+          _('foo.bar baz').
             must_be_parsed_as s(:call,
                                 s(:call, nil, :foo),
                                 :bar,
@@ -113,7 +113,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
         end
 
         it 'works with parentheses' do
-          'foo.bar(baz)'.
+          _('foo.bar(baz)').
             must_be_parsed_as s(:call,
                                 s(:call, nil, :foo),
                                 :bar,
@@ -121,7 +121,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
         end
 
         it 'works with parentheses around a call with no parentheses' do
-          'foo.bar(baz qux)'.
+          _('foo.bar(baz qux)').
             must_be_parsed_as s(:call,
                                 s(:call, nil, :foo),
                                 :bar,
@@ -130,7 +130,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
         end
 
         it 'works with nested calls without parentheses' do
-          'foo.bar baz qux'.
+          _('foo.bar baz qux').
             must_be_parsed_as s(:call,
                                 s(:call, nil, :foo),
                                 :bar,
@@ -139,14 +139,14 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
         end
 
         it 'does not keep :begin around a method receiver' do
-          'begin; foo; end.bar'.
+          _('begin; foo; end.bar').
             must_be_parsed_as s(:call, s(:call, nil, :foo), :bar)
         end
       end
 
       describe 'for collection indexing' do
         it 'works in the simple case' do
-          'foo[bar]'.
+          _('foo[bar]').
             must_be_parsed_as s(:call,
                                 s(:call, nil, :foo),
                                 :[],
@@ -154,23 +154,23 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
         end
 
         it 'works without any indexes' do
-          'foo[]'.must_be_parsed_as s(:call, s(:call, nil, :foo),
+          _('foo[]').must_be_parsed_as s(:call, s(:call, nil, :foo),
                                       :[])
         end
 
         it 'works with self[]' do
-          'self[foo]'.must_be_parsed_as s(:call, s(:self), :[],
+          _('self[foo]').must_be_parsed_as s(:call, s(:self), :[],
                                           s(:call, nil, :foo))
         end
       end
 
       describe 'safe call' do
         it 'works without arguments' do
-          'foo&.bar'.must_be_parsed_as s(:safe_call, s(:call, nil, :foo), :bar)
+          _('foo&.bar').must_be_parsed_as s(:safe_call, s(:call, nil, :foo), :bar)
         end
 
         it 'works with arguments' do
-          'foo&.bar baz'.
+          _('foo&.bar baz').
             must_be_parsed_as s(:safe_call,
                                 s(:call, nil, :foo),
                                 :bar,
@@ -180,7 +180,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
 
       describe 'with blocks' do
         it 'works for a do block' do
-          'foo.bar do baz; end'.
+          _('foo.bar do baz; end').
             must_be_parsed_as s(:iter,
                                 s(:call,
                                   s(:call, nil, :foo),
@@ -190,7 +190,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
         end
 
         it 'works for a do block with several statements' do
-          'foo.bar do baz; qux; end'.
+          _('foo.bar do baz; qux; end').
             must_be_parsed_as s(:iter,
                                 s(:call,
                                   s(:call, nil, :foo),
@@ -204,24 +204,24 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
     end
 
     describe 'for calls to super' do
-      specify { 'super'.must_be_parsed_as s(:zsuper) }
+      specify { _('super').must_be_parsed_as s(:zsuper) }
       specify do
-        'super foo'.must_be_parsed_as s(:super,
+        _('super foo').must_be_parsed_as s(:super,
                                         s(:call, nil, :foo))
       end
       specify do
-        'super foo, bar'.must_be_parsed_as s(:super,
+        _('super foo, bar').must_be_parsed_as s(:super,
                                              s(:call, nil, :foo),
                                              s(:call, nil, :bar))
       end
       specify do
-        'super foo, *bar'.must_be_parsed_as s(:super,
+        _('super foo, *bar').must_be_parsed_as s(:super,
                                               s(:call, nil, :foo),
                                               s(:splat,
                                                 s(:call, nil, :bar)))
       end
       specify do
-        'super foo, *bar, &baz'.
+        _('super foo, *bar, &baz').
           must_be_parsed_as s(:super,
                               s(:call, nil, :foo),
                               s(:splat, s(:call, nil, :bar)),
@@ -230,7 +230,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
     end
 
     it 'handles calling a proc' do
-      'foo.()'.
+      _('foo.()').
         must_be_parsed_as s(:call, s(:call, nil, :foo), :call)
     end
   end
@@ -244,7 +244,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
                  s(:vcall, s(:@ident, 'foo', s(1, 0))),
                  :'.',
                  s(:@ident, 'bar', s(1, 4)))
-        processor.process(sexp).must_equal s(:call, s(:call, nil, :foo), :bar)
+        _(processor.process(sexp)).must_equal s(:call, s(:call, nil, :foo), :bar)
       end
 
       it 'processes a Ruby 2.6 style period Sexp' do
@@ -252,7 +252,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
                  s(:vcall, s(:@ident, 'foo', s(1, 0))),
                  s(:@period, '.', s(1, 3)),
                  s(:@ident, 'bar', s(1, 4)))
-        processor.process(sexp).must_equal s(:call, s(:call, nil, :foo), :bar)
+        _(processor.process(sexp)).must_equal s(:call, s(:call, nil, :foo), :bar)
       end
 
       it 'raises an error for an unknown call operator' do
@@ -260,7 +260,7 @@ describe RipperRubyParser::SexpHandlers::MethodCalls do
                  s(:vcall, s(:@ident, 'foo', s(1, 0))),
                  :'>.',
                  s(:@ident, 'bar', s(1, 4)))
-        -> { processor.process(sexp) }.must_raise
+        _(-> { processor.process(sexp) }).must_raise
       end
     end
   end

--- a/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
@@ -6,7 +6,7 @@ describe RipperRubyParser::Parser do
   describe '#parse' do
     describe 'for instance method definitions' do
       it 'treats kwargs as a local variable' do
-        'def foo(**bar); bar; end'.
+        _('def foo(**bar); bar; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args, :"**bar"),
@@ -14,7 +14,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'treats kwargs as a local variable when other arguments are present' do
-        'def foo(bar, **baz); baz; end'.
+        _('def foo(bar, **baz); baz; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args, :bar, :"**baz"),
@@ -22,7 +22,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'treats kwargs as a local variable when an explicit block is present' do
-        'def foo(**bar, &baz); bar; end'.
+        _('def foo(**bar, &baz); bar; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args, :"**bar", :"&baz"),
@@ -30,7 +30,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'treats block kwargs as lvars' do
-        'def foo(**bar); baz { |**qux| bar; qux }; end'.
+        _('def foo(**bar); baz { |**qux| bar; qux }; end').
           must_be_parsed_as s(:defn, :foo,
                               s(:args, :"**bar"),
                               s(:iter,
@@ -42,7 +42,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a method argument with a default value' do
-        'def foo bar=nil; end'.
+        _('def foo bar=nil; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args, s(:lasgn, :bar, s(:nil))),
@@ -50,7 +50,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with several method arguments with default values' do
-        'def foo bar=1, baz=2; end'.
+        _('def foo bar=1, baz=2; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args,
@@ -60,22 +60,22 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with parentheses around the parameter list' do
-        'def foo(bar); end'.
+        _('def foo(bar); end').
           must_be_parsed_as s(:defn, :foo, s(:args, :bar), s(:nil))
       end
 
       it 'works with a simple splat' do
-        'def foo *bar; end'.
+        _('def foo *bar; end').
           must_be_parsed_as s(:defn, :foo, s(:args, :"*bar"), s(:nil))
       end
 
       it 'works with a regular argument plus splat' do
-        'def foo bar, *baz; end'.
+        _('def foo bar, *baz; end').
           must_be_parsed_as s(:defn, :foo, s(:args, :bar, :"*baz"), s(:nil))
       end
 
       it 'works with a nameless splat' do
-        'def foo *; end'.
+        _('def foo *; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args, :"*"),
@@ -83,7 +83,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works for a simple case with explicit block parameter' do
-        'def foo &bar; end'.
+        _('def foo &bar; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args, :"&bar"),
@@ -91,7 +91,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a regular argument plus explicit block parameter' do
-        'def foo bar, &baz; end'.
+        _('def foo bar, &baz; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args, :bar, :"&baz"),
@@ -99,7 +99,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a default value plus explicit block parameter' do
-        'def foo bar=1, &baz; end'.
+        _('def foo bar=1, &baz; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args,
@@ -109,7 +109,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a default value plus mandatory argument' do
-        'def foo bar=1, baz; end'.
+        _('def foo bar=1, baz; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args,
@@ -119,7 +119,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a splat plus explicit block parameter' do
-        'def foo *bar, &baz; end'.
+        _('def foo *bar, &baz; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args, :"*bar", :"&baz"),
@@ -127,7 +127,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a default value plus splat' do
-        'def foo bar=1, *baz; end'.
+        _('def foo bar=1, *baz; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args,
@@ -137,7 +137,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a default value, splat, plus final mandatory arguments' do
-        'def foo bar=1, *baz, qux, quuz; end'.
+        _('def foo bar=1, *baz, qux, quuz; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args,
@@ -147,7 +147,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a named argument with a default value' do
-        'def foo bar: 1; end'.
+        _('def foo bar: 1; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args,
@@ -156,7 +156,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a named argument with no default value' do
-        'def foo bar:; end'.
+        _('def foo bar:; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args,
@@ -165,7 +165,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a double splat' do
-        'def foo **bar; end'.
+        _('def foo **bar; end').
           must_be_parsed_as s(:defn,
                               :foo,
                               s(:args, :'**bar'),
@@ -173,40 +173,40 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with argument destructuring' do
-        'def foo((bar, baz)); end'.
+        _('def foo((bar, baz)); end').
           must_be_parsed_as s(:defn, :foo,
                               s(:args, s(:masgn, :bar, :baz)),
                               s(:nil))
       end
 
       it 'works with argument destructuring including splat' do
-        'def foo((bar, *baz)); end'.
+        _('def foo((bar, *baz)); end').
           must_be_parsed_as s(:defn, :foo,
                               s(:args, s(:masgn, :bar, :'*baz')),
                               s(:nil))
       end
 
       it 'works with nested argument destructuring' do
-        'def foo((bar, (baz, qux))); end'.
+        _('def foo((bar, (baz, qux))); end').
           must_be_parsed_as s(:defn, :foo,
                               s(:args, s(:masgn, :bar, s(:masgn, :baz, :qux))),
                               s(:nil))
       end
 
       it 'works when the method name is an operator' do
-        'def +; end'.
+        _('def +; end').
           must_be_parsed_as s(:defn, :+, s(:args),
                               s(:nil))
       end
 
       it 'works when the method name is a keyword' do
-        'def for; end'.
+        _('def for; end').
           must_be_parsed_as s(:defn, :for, s(:args),
                               s(:nil))
       end
 
       it 'assigns correct line numbers when the body is empty' do
-        "def bar\nend".
+        _("def bar\nend").
           must_be_parsed_as s(:defn,
                               :bar,
                               s(:args).line(1),
@@ -217,7 +217,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for singleton method definitions' do
       it 'works with empty body' do
-        'def foo.bar; end'.
+        _('def foo.bar; end').
           must_be_parsed_as s(:defs,
                               s(:call, nil, :foo),
                               :bar,
@@ -226,7 +226,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a body with multiple statements' do
-        'def foo.bar; baz; qux; end'.
+        _('def foo.bar; baz; qux; end').
           must_be_parsed_as s(:defs,
                               s(:call, nil, :foo),
                               :bar,
@@ -236,7 +236,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a simple splat' do
-        'def foo.bar *baz; end'.
+        _('def foo.bar *baz; end').
           must_be_parsed_as s(:defs,
                               s(:call, nil, :foo),
                               :bar,
@@ -245,7 +245,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works when the method name is a keyword' do
-        'def foo.for; end'.
+        _('def foo.for; end').
           must_be_parsed_as s(:defs,
                               s(:call, nil, :foo),
                               :for, s(:args),
@@ -255,54 +255,54 @@ describe RipperRubyParser::Parser do
 
     describe 'for the alias statement' do
       it 'works with regular barewords' do
-        'alias foo bar'.
+        _('alias foo bar').
           must_be_parsed_as s(:alias,
                               s(:lit, :foo), s(:lit, :bar))
       end
 
       it 'works with symbols' do
-        'alias :foo :bar'.
+        _('alias :foo :bar').
           must_be_parsed_as s(:alias,
                               s(:lit, :foo), s(:lit, :bar))
       end
 
       it 'works with operator barewords' do
-        'alias + -'.
+        _('alias + -').
           must_be_parsed_as s(:alias,
                               s(:lit, :+), s(:lit, :-))
       end
 
       it 'treats keywords as symbols' do
-        'alias next foo'.
+        _('alias next foo').
           must_be_parsed_as s(:alias, s(:lit, :next), s(:lit, :foo))
       end
 
       it 'works with global variables' do
-        'alias $foo $bar'.
+        _('alias $foo $bar').
           must_be_parsed_as s(:valias, :$foo, :$bar)
       end
     end
 
     describe 'for the undef statement' do
       it 'works with a single bareword identifier' do
-        'undef foo'.
+        _('undef foo').
           must_be_parsed_as s(:undef, s(:lit, :foo))
       end
 
       it 'works with a single symbol' do
-        'undef :foo'.
+        _('undef :foo').
           must_be_parsed_as s(:undef, s(:lit, :foo))
       end
 
       it 'works with multiple bareword identifiers' do
-        'undef foo, bar'.
+        _('undef foo, bar').
           must_be_parsed_as s(:block,
                               s(:undef, s(:lit, :foo)),
                               s(:undef, s(:lit, :bar)))
       end
 
       it 'works with multiple bareword symbols' do
-        'undef :foo, :bar'.
+        _('undef :foo, :bar').
           must_be_parsed_as s(:block,
                               s(:undef, s(:lit, :foo)),
                               s(:undef, s(:lit, :bar)))
@@ -311,18 +311,18 @@ describe RipperRubyParser::Parser do
 
     describe 'for the return statement' do
       it 'works with no arguments' do
-        'return'.
+        _('return').
           must_be_parsed_as s(:return)
       end
 
       it 'works with one argument' do
-        'return foo'.
+        _('return foo').
           must_be_parsed_as s(:return,
                               s(:call, nil, :foo))
       end
 
       it 'works with a splat argument' do
-        'return *foo'.
+        _('return *foo').
           must_be_parsed_as s(:return,
                               s(:svalue,
                                 s(:splat,
@@ -330,7 +330,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with multiple arguments' do
-        'return foo, bar'.
+        _('return foo, bar').
           must_be_parsed_as s(:return,
                               s(:array,
                                 s(:call, nil, :foo),
@@ -338,7 +338,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a regular argument and a splat argument' do
-        'return foo, *bar'.
+        _('return foo, *bar').
           must_be_parsed_as s(:return,
                               s(:array,
                                 s(:call, nil, :foo),
@@ -347,14 +347,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'works with a function call with parentheses' do
-        'return foo(bar)'.
+        _('return foo(bar)').
           must_be_parsed_as s(:return,
                               s(:call, nil, :foo,
                                 s(:call, nil, :bar)))
       end
 
       it 'works with a function call without parentheses' do
-        'return foo bar'.
+        _('return foo bar').
           must_be_parsed_as s(:return,
                               s(:call, nil, :foo,
                                 s(:call, nil, :bar)))
@@ -363,55 +363,55 @@ describe RipperRubyParser::Parser do
 
     describe 'for yield' do
       it 'works with no arguments and no parentheses' do
-        'yield'.
+        _('yield').
           must_be_parsed_as s(:yield)
       end
 
       it 'works with parentheses but no arguments' do
-        'yield()'.
+        _('yield()').
           must_be_parsed_as s(:yield)
       end
 
       it 'works with one argument and no parentheses' do
-        'yield foo'.
+        _('yield foo').
           must_be_parsed_as s(:yield, s(:call, nil, :foo))
       end
 
       it 'works with one argument and parentheses' do
-        'yield(foo)'.
+        _('yield(foo)').
           must_be_parsed_as s(:yield, s(:call, nil, :foo))
       end
 
       it 'works with multiple arguments and no parentheses' do
-        'yield foo, bar'.
+        _('yield foo, bar').
           must_be_parsed_as s(:yield,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar))
       end
 
       it 'works with multiple arguments and parentheses' do
-        'yield(foo, bar)'.
+        _('yield(foo, bar)').
           must_be_parsed_as s(:yield,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar))
       end
 
       it 'works with splat' do
-        'yield foo, *bar'.
+        _('yield foo, *bar').
           must_be_parsed_as s(:yield,
                               s(:call, nil, :foo),
                               s(:splat, s(:call, nil, :bar)))
       end
 
       it 'works with a function call with parentheses' do
-        'yield foo(bar)'.
+        _('yield foo(bar)').
           must_be_parsed_as s(:yield,
                               s(:call, nil, :foo,
                                 s(:call, nil, :bar)))
       end
 
       it 'works with a function call without parentheses' do
-        'yield foo bar'.
+        _('yield foo bar').
           must_be_parsed_as s(:yield,
                               s(:call, nil, :foo,
                                 s(:call, nil, :bar)))
@@ -420,7 +420,7 @@ describe RipperRubyParser::Parser do
 
     describe 'when extra compatibility is turned on' do
       it 'still treats block kwargs as lvars' do
-        'def foo(**bar); baz { |**qux| bar; qux }; end'.
+        _('def foo(**bar); baz { |**qux| bar; qux }; end').
           must_be_parsed_as s(:defn, :foo,
                               s(:args, :"**bar"),
                               s(:iter,

--- a/test/ripper_ruby_parser/sexp_handlers/operators_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/operators_test.rb
@@ -6,14 +6,14 @@ describe RipperRubyParser::Parser do
   describe '#parse' do
     describe 'for boolean operators' do
       it 'handles :and' do
-        'foo and bar'.
+        _('foo and bar').
           must_be_parsed_as s(:and,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar))
       end
 
       it 'handles double :and' do
-        'foo and bar and baz'.
+        _('foo and bar and baz').
           must_be_parsed_as s(:and,
                               s(:call, nil, :foo),
                               s(:and,
@@ -22,14 +22,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles :or' do
-        'foo or bar'.
+        _('foo or bar').
           must_be_parsed_as s(:or,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar))
       end
 
       it 'handles double :or' do
-        'foo or bar or baz'.
+        _('foo or bar or baz').
           must_be_parsed_as s(:or,
                               s(:call, nil, :foo),
                               s(:or,
@@ -38,7 +38,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles :or after :and' do
-        'foo and bar or baz'.
+        _('foo and bar or baz').
           must_be_parsed_as s(:or,
                               s(:and,
                                 s(:call, nil, :foo),
@@ -47,7 +47,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles :and after :or' do
-        'foo or bar and baz'.
+        _('foo or bar and baz').
           must_be_parsed_as s(:and,
                               s(:or,
                                 s(:call, nil, :foo),
@@ -56,14 +56,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'converts :&& to :and' do
-        'foo && bar'.
+        _('foo && bar').
           must_be_parsed_as s(:and,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar))
       end
 
       it 'handles :|| after :&&' do
-        'foo && bar || baz'.
+        _('foo && bar || baz').
           must_be_parsed_as s(:or,
                               s(:and,
                                 s(:call, nil, :foo),
@@ -72,7 +72,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles :&& after :||' do
-        'foo || bar && baz'.
+        _('foo || bar && baz').
           must_be_parsed_as s(:or,
                               s(:call, nil, :foo),
                               s(:and,
@@ -81,7 +81,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles :|| with parentheses' do
-        '(foo || bar) || baz'.
+        _('(foo || bar) || baz').
           must_be_parsed_as s(:or,
                               s(:or,
                                 s(:call, nil, :foo),
@@ -90,7 +90,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles nested :|| with parentheses' do
-        'foo || (bar || baz) || qux'.
+        _('foo || (bar || baz) || qux').
           must_be_parsed_as  s(:or,
                                s(:call, nil, :foo),
                                s(:or,
@@ -99,14 +99,14 @@ describe RipperRubyParser::Parser do
       end
 
       it 'converts :|| to :or' do
-        'foo || bar'.
+        _('foo || bar').
           must_be_parsed_as s(:or,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar))
       end
 
       it 'handles triple :and' do
-        'foo and bar and baz and qux'.
+        _('foo and bar and baz and qux').
           must_be_parsed_as s(:and,
                               s(:call, nil, :foo),
                               s(:and,
@@ -117,7 +117,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles triple :&&' do
-        'foo && bar && baz && qux'.
+        _('foo && bar && baz && qux').
           must_be_parsed_as s(:and,
                               s(:call, nil, :foo),
                               s(:and,
@@ -128,7 +128,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles :!=' do
-        'foo != bar'.
+        _('foo != bar').
           must_be_parsed_as s(:call,
                               s(:call, nil, :foo),
                               :!=,
@@ -136,7 +136,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'keeps :begin for the first argument of a binary operator' do
-        'begin; bar; end + foo'.
+        _('begin; bar; end + foo').
           must_be_parsed_as s(:call,
                               s(:begin, s(:call, nil, :bar)),
                               :+,
@@ -144,7 +144,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'keeps :begin for the second argument of a binary operator' do
-        'foo + begin; bar; end'.
+        _('foo + begin; bar; end').
           must_be_parsed_as s(:call,
                               s(:call, nil, :foo),
                               :+,
@@ -152,21 +152,21 @@ describe RipperRubyParser::Parser do
       end
 
       it 'does not keep :begin for the first argument of a boolean operator' do
-        'begin; bar; end and foo'.
+        _('begin; bar; end and foo').
           must_be_parsed_as s(:and,
                               s(:call, nil, :bar),
                               s(:call, nil, :foo))
       end
 
       it 'keeps :begin for the second argument of a boolean operator' do
-        'foo and begin; bar; end'.
+        _('foo and begin; bar; end').
           must_be_parsed_as s(:and,
                               s(:call, nil, :foo),
                               s(:begin, s(:call, nil, :bar)))
       end
 
       it 'does not keep :begin for the first argument of a shift operator' do
-        'begin; bar; end << foo'.
+        _('begin; bar; end << foo').
           must_be_parsed_as s(:call,
                               s(:call, nil, :bar),
                               :<<,
@@ -174,7 +174,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'does not keep :begin for the second argument of a shift operator' do
-        'foo >> begin; bar; end'.
+        _('foo >> begin; bar; end').
           must_be_parsed_as s(:call,
                               s(:call, nil, :foo),
                               :>>,
@@ -184,45 +184,45 @@ describe RipperRubyParser::Parser do
 
     describe 'for the range operator' do
       it 'handles positive number literals' do
-        '1..2'.
+        _('1..2').
           must_be_parsed_as s(:lit, 1..2)
       end
 
       it 'handles negative number literals' do
-        '-1..-2'.
+        _('-1..-2').
           must_be_parsed_as s(:lit, -1..-2)
       end
 
       it 'handles float literals' do
-        '1.0..2.0'.
+        _('1.0..2.0').
           must_be_parsed_as s(:dot2,
                               s(:lit, 1.0),
                               s(:lit, 2.0))
       end
 
       it 'handles string literals' do
-        "'a'..'z'".
+        _("'a'..'z'").
           must_be_parsed_as s(:dot2,
                               s(:str, 'a'),
                               s(:str, 'z'))
       end
 
       it 'handles non-literal begin' do
-        'foo..3'.
+        _('foo..3').
           must_be_parsed_as s(:dot2,
                               s(:call, nil, :foo),
                               s(:lit, 3))
       end
 
       it 'handles non-literal end' do
-        '3..foo'.
+        _('3..foo').
           must_be_parsed_as s(:dot2,
                               s(:lit, 3),
                               s(:call, nil, :foo))
       end
 
       it 'handles non-literals' do
-        'foo..bar'.
+        _('foo..bar').
           must_be_parsed_as s(:dot2,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar))
@@ -231,45 +231,45 @@ describe RipperRubyParser::Parser do
 
     describe 'for the exclusive range operator' do
       it 'handles positive number literals' do
-        '1...2'.
+        _('1...2').
           must_be_parsed_as s(:lit, 1...2)
       end
 
       it 'handles negative number literals' do
-        '-1...-2'.
+        _('-1...-2').
           must_be_parsed_as s(:lit, -1...-2)
       end
 
       it 'handles float literals' do
-        '1.0...2.0'.
+        _('1.0...2.0').
           must_be_parsed_as s(:dot3,
                               s(:lit, 1.0),
                               s(:lit, 2.0))
       end
 
       it 'handles string literals' do
-        "'a'...'z'".
+        _("'a'...'z'").
           must_be_parsed_as s(:dot3,
                               s(:str, 'a'),
                               s(:str, 'z'))
       end
 
       it 'handles non-literal begin' do
-        'foo...3'.
+        _('foo...3').
           must_be_parsed_as s(:dot3,
                               s(:call, nil, :foo),
                               s(:lit, 3))
       end
 
       it 'handles non-literal end' do
-        '3...foo'.
+        _('3...foo').
           must_be_parsed_as s(:dot3,
                               s(:lit, 3),
                               s(:call, nil, :foo))
       end
 
       it 'handles two non-literals' do
-        'foo...bar'.
+        _('foo...bar').
           must_be_parsed_as s(:dot3,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar))
@@ -278,52 +278,52 @@ describe RipperRubyParser::Parser do
 
     describe 'for unary operators' do
       it 'handles unary minus with an integer literal' do
-        '- 1'.must_be_parsed_as s(:call, s(:lit, 1), :-@)
+        _('- 1').must_be_parsed_as s(:call, s(:lit, 1), :-@)
       end
 
       it 'handles unary minus with a float literal' do
-        '- 3.14'.must_be_parsed_as s(:call, s(:lit, 3.14), :-@)
+        _('- 3.14').must_be_parsed_as s(:call, s(:lit, 3.14), :-@)
       end
 
       it 'handles unary minus with a non-literal' do
-        '-foo'.
+        _('-foo').
           must_be_parsed_as s(:call,
                               s(:call, nil, :foo),
                               :-@)
       end
 
       it 'handles unary minus with a negative number literal' do
-        '- -1'.must_be_parsed_as s(:call, s(:lit, -1), :-@)
+        _('- -1').must_be_parsed_as s(:call, s(:lit, -1), :-@)
       end
 
       it 'handles unary plus with a number literal' do
-        '+ 1'.must_be_parsed_as s(:call, s(:lit, 1), :+@)
+        _('+ 1').must_be_parsed_as s(:call, s(:lit, 1), :+@)
       end
 
       it 'handles unary plus with a non-literal' do
-        '+foo'.
+        _('+foo').
           must_be_parsed_as s(:call,
                               s(:call, nil, :foo),
                               :+@)
       end
 
       it 'handles unary !' do
-        '!foo'.
+        _('!foo').
           must_be_parsed_as s(:call, s(:call, nil, :foo), :!)
       end
 
       it 'converts :not to :!' do
-        'not foo'.
+        _('not foo').
           must_be_parsed_as s(:call, s(:call, nil, :foo), :!)
       end
 
       it 'handles unary ! with a number literal' do
-        '!1'.
+        _('!1').
           must_be_parsed_as s(:call, s(:lit, 1), :!)
       end
 
       it 'keeps :begin for the argument' do
-        '- begin; foo; end'.
+        _('- begin; foo; end').
           must_be_parsed_as s(:call,
                               s(:begin, s(:call, nil, :foo)),
                               :-@)
@@ -332,7 +332,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for the ternary operater' do
       it 'works in the simple case' do
-        'foo ? bar : baz'.
+        _('foo ? bar : baz').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -340,7 +340,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'keeps :begin for the first argument' do
-        'begin; foo; end ? bar : baz'.
+        _('begin; foo; end ? bar : baz').
           must_be_parsed_as s(:if,
                               s(:begin, s(:call, nil, :foo)),
                               s(:call, nil, :bar),
@@ -348,7 +348,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'keeps :begin for the second argument' do
-        'foo ? begin; bar; end : baz'.
+        _('foo ? begin; bar; end : baz').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:begin, s(:call, nil, :bar)),
@@ -356,7 +356,7 @@ describe RipperRubyParser::Parser do
       end
 
       it 'keeps :begin for the third argument' do
-        'foo ? bar : begin; baz; end'.
+        _('foo ? bar : begin; baz; end').
           must_be_parsed_as s(:if,
                               s(:call, nil, :foo),
                               s(:call, nil, :bar),
@@ -366,7 +366,7 @@ describe RipperRubyParser::Parser do
 
     describe 'for match operators' do
       it 'handles :=~ with two non-literals' do
-        'foo =~ bar'.
+        _('foo =~ bar').
           must_be_parsed_as s(:call,
                               s(:call, nil, :foo),
                               :=~,
@@ -374,21 +374,21 @@ describe RipperRubyParser::Parser do
       end
 
       it 'handles :=~ with literal regexp on the left hand side' do
-        '/foo/ =~ bar'.
+        _('/foo/ =~ bar').
           must_be_parsed_as s(:match2,
                               s(:lit, /foo/),
                               s(:call, nil, :bar))
       end
 
       it 'handles :=~ with literal regexp on the right hand side' do
-        'foo =~ /bar/'.
+        _('foo =~ /bar/').
           must_be_parsed_as s(:match3,
                               s(:lit, /bar/),
                               s(:call, nil, :foo))
       end
 
       it 'handles negated match operators' do
-        'foo !~ bar'.must_be_parsed_as s(:not,
+        _('foo !~ bar').must_be_parsed_as s(:not,
                                          s(:call,
                                            s(:call, nil, :foo),
                                            :=~,

--- a/test/ripper_ruby_parser/sexp_processor_test.rb
+++ b/test/ripper_ruby_parser/sexp_processor_test.rb
@@ -29,13 +29,13 @@ describe RipperRubyParser::SexpProcessor do
       it 'strips off the outer :program node' do
         sexp = s(:program, s(:stmts, s(:foo)))
         result = processor.process sexp
-        result.must_equal s(:foo_p)
+        _(result).must_equal s(:foo_p)
       end
 
       it 'transforms a multi-statement :program into a :block sexp' do
         sexp = s(:program, s(:stmts, s(:foo), s(:bar)))
         result = processor.process sexp
-        result.must_equal s(:block, s(:foo_p), s(:bar_p))
+        _(result).must_equal s(:block, s(:foo_p), s(:bar_p))
       end
     end
 
@@ -45,7 +45,7 @@ describe RipperRubyParser::SexpProcessor do
                  s(:string_content,
                    s(:@tstring_content, 'foo', s(1, 1), '"')))
         result = processor.process sexp
-        result.must_equal s(:str, 'foo')
+        _(result).must_equal s(:str, 'foo')
       end
     end
 
@@ -53,7 +53,7 @@ describe RipperRubyParser::SexpProcessor do
       it 'transforms a sexp to a :call' do
         sexp = s(:command, s(:@ident, 'foo', s(1, 0)), s(:arglist, s(:foo)))
         result = processor.process sexp
-        result.must_equal s(:call, nil, :foo, s(:foo_p))
+        _(result).must_equal s(:call, nil, :foo, s(:foo_p))
       end
     end
 
@@ -61,7 +61,7 @@ describe RipperRubyParser::SexpProcessor do
       it 'transforms the sexp to a :lvar sexp' do
         sexp = s(:var_ref, s(:@ident, 'bar', s(1, 4)))
         result = processor.process sexp
-        result.must_equal s(:lvar, :bar)
+        _(result).must_equal s(:lvar, :bar)
       end
     end
 
@@ -69,7 +69,7 @@ describe RipperRubyParser::SexpProcessor do
       it 'transforms the sexp to a :call sexp' do
         sexp = s(:vcall, s(:@ident, 'bar', s(1, 4)))
         result = processor.process sexp
-        result.must_equal s(:call, nil, :bar)
+        _(result).must_equal s(:call, nil, :bar)
       end
     end
 
@@ -79,7 +79,7 @@ describe RipperRubyParser::SexpProcessor do
                  s(:const_ref, s(:@const, 'Foo', s(1, 13))),
                  s(:bodystmt, s(:stmts, s(:void_stmt, s(2, 3))), nil, nil, nil))
         result = processor.process sexp
-        result.must_equal s(:module, :Foo)
+        _(result).must_equal s(:module, :Foo)
       end
 
       it 'creates a single body element for a definition with one statement' do
@@ -87,7 +87,7 @@ describe RipperRubyParser::SexpProcessor do
                  s(:const_ref, s(:@const, 'Foo', s(1, 13))),
                  s(:bodystmt, s(:stmts, s(:foo)), nil, nil, nil))
         result = processor.process sexp
-        result.must_equal s(:module, :Foo, s(:foo_p))
+        _(result).must_equal s(:module, :Foo, s(:foo_p))
       end
 
       it 'creates multiple body elements for a definition with more than one statement' do
@@ -95,7 +95,7 @@ describe RipperRubyParser::SexpProcessor do
                  s(:const_ref, s(:@const, 'Foo', s(1, 13))),
                  s(:bodystmt, s(:stmts, s(:foo), s(:bar)), nil, nil, nil))
         result = processor.process sexp
-        result.must_equal s(:module, :Foo, s(:foo_p), s(:bar_p))
+        _(result).must_equal s(:module, :Foo, s(:foo_p), s(:bar_p))
       end
     end
 
@@ -105,7 +105,7 @@ describe RipperRubyParser::SexpProcessor do
                  s(:const_ref, s(:@const, 'Foo', s(1, 13))), nil,
                  s(:bodystmt, s(:stmts, s(:void_stmt, s(2, 8))), nil, nil, nil))
         result = processor.process sexp
-        result.must_equal s(:class, :Foo, nil)
+        _(result).must_equal s(:class, :Foo, nil)
       end
 
       it 'creates a single body element for a definition with one statement' do
@@ -113,7 +113,7 @@ describe RipperRubyParser::SexpProcessor do
                  s(:const_ref, s(:@const, 'Foo', s(1, 13))), nil,
                  s(:bodystmt, s(:stmts, s(:foo)), nil, nil, nil))
         result = processor.process sexp
-        result.must_equal s(:class, :Foo, nil, s(:foo_p))
+        _(result).must_equal s(:class, :Foo, nil, s(:foo_p))
       end
 
       it 'creates multiple body elements for a definition with more than one statement' do
@@ -121,7 +121,7 @@ describe RipperRubyParser::SexpProcessor do
                  s(:const_ref, s(:@const, 'Foo', s(1, 13))), nil,
                  s(:bodystmt, s(:stmts, s(:foo), s(:bar)), nil, nil, nil))
         result = processor.process sexp
-        result.must_equal s(:class, :Foo, nil, s(:foo_p), s(:bar_p))
+        _(result).must_equal s(:class, :Foo, nil, s(:foo_p), s(:bar_p))
       end
 
       it 'passes on the given ancestor' do
@@ -130,7 +130,7 @@ describe RipperRubyParser::SexpProcessor do
                  s(:var_ref, s(:@const, 'Bar', s(1, 12))),
                  s(:bodystmt, s(:stmts, s(:void_stmt, s(2, 7))), nil, nil, nil))
         result = processor.process sexp
-        result.must_equal s(:class, :Foo, s(:const, :Bar))
+        _(result).must_equal s(:class, :Foo, s(:const, :Bar))
       end
     end
 
@@ -138,13 +138,13 @@ describe RipperRubyParser::SexpProcessor do
       it 'creates a :block sexp when multiple statements are present' do
         sexp = s(:bodystmt, s(:stmts, s(:foo), s(:bar)), nil, nil, nil)
         result = processor.process sexp
-        result.must_equal s(:block, s(:foo_p), s(:bar_p))
+        _(result).must_equal s(:block, s(:foo_p), s(:bar_p))
       end
 
       it 'removes nested :void_stmt sexps' do
         sexp = s(:bodystmt, s(:stmts, s(:void_stmt), s(:foo)), nil, nil, nil)
         result = processor.process sexp
-        result.must_equal s(:foo_p)
+        _(result).must_equal s(:foo_p)
       end
     end
 
@@ -155,7 +155,7 @@ describe RipperRubyParser::SexpProcessor do
                  s(:params, nil, nil, nil, nil, nil),
                  s(:bodystmt, s(:stmts, s(:void_stmt, s(2, 3))), nil, nil, nil))
         result = processor.process sexp
-        result.must_equal s(:defn, :foo, s(:args), s(:nil))
+        _(result).must_equal s(:defn, :foo, s(:args), s(:nil))
       end
     end
 
@@ -164,7 +164,7 @@ describe RipperRubyParser::SexpProcessor do
         it 'creates :lvar sexps' do
           sexp =  s(:params, s(s(:@ident, 'bar', s(1, 8))), nil, nil, nil, nil)
           result = processor.process sexp
-          result.must_equal s(:args, s(:lvar, :bar))
+          _(result).must_equal s(:args, s(:lvar, :bar))
         end
       end
 
@@ -175,7 +175,7 @@ describe RipperRubyParser::SexpProcessor do
                     s(:@ident, 'bar', s(1, 8)),
                     nil)
           result = processor.process sexp
-          result.must_equal s(:args, s(:dsplat, s(:lvar, :bar)))
+          _(result).must_equal s(:args, s(:dsplat, s(:lvar, :bar)))
         end
       end
       describe 'with a ruby 2.5-style kwrest argument' do
@@ -185,7 +185,7 @@ describe RipperRubyParser::SexpProcessor do
                     s(:kwrest_param, s(:@ident, 'bar', s(1, 8))),
                     nil)
           result = processor.process sexp
-          result.must_equal s(:args, s(:dsplat, s(:lvar, :bar)))
+          _(result).must_equal s(:args, s(:dsplat, s(:lvar, :bar)))
         end
       end
     end
@@ -196,7 +196,7 @@ describe RipperRubyParser::SexpProcessor do
                  s(:var_field, s(:@ident, 'a', s(1, 0))),
                  s(:@int, '1', s(1, 4)))
         result = processor.process sexp
-        result.must_equal s(:lasgn, :a, s(:lit, 1))
+        _(result).must_equal s(:lasgn, :a, s(:lit, 1))
       end
     end
 
@@ -204,7 +204,7 @@ describe RipperRubyParser::SexpProcessor do
       it 'creates a :call sexp' do
         sexp = s(:binary, s(:bar), :==, s(:foo))
         result = processor.process sexp
-        result.must_equal s(:call, s(:bar_p), :==, s(:foo_p))
+        _(result).must_equal s(:call, s(:bar_p), :==, s(:foo_p))
       end
     end
 
@@ -214,7 +214,7 @@ describe RipperRubyParser::SexpProcessor do
                  s(:call, s(:foo), :".", s(:@ident, 'baz', s(1, 2))),
                  s(:brace_block, nil, s(:stmts, s(:bar))))
         result = processor.process sexp
-        result.must_equal s(:iter,
+        _(result).must_equal s(:iter,
                             s(:call, s(:foo_p), :baz), 0,
                             s(:bar_p))
       end
@@ -229,7 +229,7 @@ describe RipperRubyParser::SexpProcessor do
                        nil),
                      s(:stmts, s(:bar))))
           result = processor.process sexp
-          result.must_equal s(:iter,
+          _(result).must_equal s(:iter,
                               s(:call, s(:foo_p), :baz),
                               s(:args, :i),
                               s(:bar_p))
@@ -242,7 +242,7 @@ describe RipperRubyParser::SexpProcessor do
         it 'uses the statement sexp as the body' do
           sexp = s(:if, s(:foo), s(:stmts, s(:bar)), nil)
           result = processor.process sexp
-          result.must_equal s(:if, s(:foo_p), s(:bar_p), nil)
+          _(result).must_equal s(:if, s(:foo_p), s(:bar_p), nil)
         end
       end
 
@@ -250,7 +250,7 @@ describe RipperRubyParser::SexpProcessor do
         it 'uses a block containing the statement sexps as the body' do
           sexp = s(:if, s(:foo), s(:stmts, s(:bar), s(:baz)), nil)
           result = processor.process sexp
-          result.must_equal s(:if, s(:foo_p), s(:block, s(:bar_p), s(:baz_p)), nil)
+          _(result).must_equal s(:if, s(:foo_p), s(:block, s(:bar_p), s(:baz_p)), nil)
         end
       end
     end
@@ -259,7 +259,7 @@ describe RipperRubyParser::SexpProcessor do
       it 'pulls up the element sexps' do
         sexp = s(:array, s(:words, s(:foo), s(:bar), s(:baz)))
         result = processor.process sexp
-        result.must_equal s(:array, s(:foo_p), s(:bar_p), s(:baz_p))
+        _(result).must_equal s(:array, s(:foo_p), s(:bar_p), s(:baz_p))
       end
     end
 
@@ -269,7 +269,7 @@ describe RipperRubyParser::SexpProcessor do
                  s(:var_ref, s(:@const, 'Foo', s(1, 0))),
                  s(:@const, 'Bar', s(1, 5)))
         result = processor.process sexp
-        result.must_equal s(:colon2, s(:const, :Foo), :Bar)
+        _(result).must_equal s(:colon2, s(:const, :Foo), :Bar)
       end
     end
 
@@ -279,7 +279,7 @@ describe RipperRubyParser::SexpProcessor do
                  s(:when, s(:args, s(:foo)), s(:stmts, s(:bar)),
                    s(:when, s(:args, s(:foo)), s(:stmts, s(:bar)), nil)))
         result = processor.process sexp
-        result.must_equal s(s(:when, s(:array, s(:foo_p)), s(:bar_p)),
+        _(result).must_equal s(s(:when, s(:array, s(:foo_p)), s(:bar_p)),
                             s(:when, s(:array, s(:foo_p)), s(:bar_p)),
                             s(:when, s(:array, s(:foo_p)), s(:bar_p)),
                             nil)
@@ -291,13 +291,13 @@ describe RipperRubyParser::SexpProcessor do
     it 'processes an lvar sexp to a bare symbol' do
       sexp = s(:lvar, 'foo')
       result = processor.send :extract_node_symbol, sexp
-      result.must_equal :foo
+      _(result).must_equal :foo
     end
 
     it 'processes a const sexp to a bare symbol' do
       sexp = s(:const, 'Foo')
       result = processor.send :extract_node_symbol, sexp
-      result.must_equal :Foo
+      _(result).must_equal :Foo
     end
   end
 end

--- a/test/ripper_ruby_parser/version_test.rb
+++ b/test/ripper_ruby_parser/version_test.rb
@@ -2,6 +2,6 @@
 
 describe RipperRubyParser do
   it 'knows its own version' do
-    RipperRubyParser::VERSION.wont_be_nil
+    _(RipperRubyParser::VERSION).wont_be_nil
   end
 end


### PR DESCRIPTION
Updates to use non-global assertion methods to avoid deprecation messages when using minitest 5.12.