### PR TITLE
Update for ruby_parser 3.14

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,9 @@ source 'https://rubygems.org'
 # The gem's dependencies are specified in the gemspec
 gemspec
 
-# For testing, do not allow sexp_processor 4.12.1: its test cases match an
-# unreleased version of ruby_parser.
-gem 'sexp_processor', ['~> 4.10', '< 4.12.1']
+# For testing, require sexp_processor 4.13.0 so its test cases match version
+# 3.14.0 of ruby_parser.
+gem 'sexp_processor', '~> 4.13.0'
 
 group :local_development do
   gem 'pry'

--- a/README.md
+++ b/README.md
@@ -11,27 +11,15 @@ Parse with Ripper, produce sexps that are compatible with RubyParser.
 * Drop-in replacement for RubyParser
 * Should handle 1.9 and later syntax gracefully
 * Requires MRI 2.3 or higher
-* Compatible with RubyParser 3.13.1
+* Compatible with RubyParser 3.14.0
 
 ## Known incompatibilities
 
-RipperRubyParser has some incompatibilities with RubyParser. For some of these,
-the behavior can be changed by turning on extra-compatible mode.
-
-The following incompatibilities cannot be changed:
+RipperRubyParser has a few incompatibilities with RubyParser.
 
 * RipperRubyParser won't handle non-UTF-8 files without an encoding comment,
   just like regular Ruby
-* RipperRubyParser does not match RubyParser's line numbering
-* RipperRubyParser correctly dedents heredocs with interpolations
-
-The following incompatibilities can be made compatible by turning on
-extra-compatible mode:
-
-* Operator assignment of a method call without parentheses to a collection
-  element uses an `:array` S-expression instead of `:arglist`
-* RipperRubyParser keeps carriage return characters in heredocs that include
-  them
+* RipperRubyParser does not always match RubyParser's line numbering
 
 ## Install
 
@@ -48,13 +36,6 @@ parser.parse "puts 'Hello World'"
 parser.parse "foo[bar] += baz qux"
 # => s(:op_asgn1, s(:call, nil, :foo),
 #      s(:arglist, s(:call, nil, :bar)),
-#      :+,
-#      s(:call, nil, :baz, s(:call, nil, :qux)))
-parser.extra_compatible = true
-
-parser.parse "foo[bar] += baz qux"
-# => s(:op_asgn1, s(:call, nil, :foo),
-#      s(:array, s(:call, nil, :bar)),
 #      :+,
 #      s(:call, nil, :baz, s(:call, nil, :qux)))
 ```

--- a/lib/ripper_ruby_parser/sexp_handlers/assignment.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/assignment.rb
@@ -127,12 +127,7 @@ module RipperRubyParser
         case lvalue.sexp_type
         when :aref_field
           _, arr, arglist = lvalue
-          arglist.sexp_type = if extra_compatible &&
-                                 [:command, :command_call].include?(original_value_type)
-                                :array
-                              else
-                                :arglist
-                              end
+          arglist.sexp_type = :arglist
           s(:op_asgn1, arr, arglist, operator, value)
         when :field
           _, obj, _, (_, field) = lvalue

--- a/lib/ripper_ruby_parser/sexp_handlers/assignment.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/assignment.rb
@@ -96,11 +96,10 @@ module RipperRubyParser
         _, lvalue, (_, operator,), value = exp.shift 4
 
         lvalue = process(lvalue)
-        original_value_type = value.sexp_type
         value = process(value)
         operator = operator.chop.to_sym
 
-        create_operator_assignment_sub_type lvalue, value, operator, original_value_type
+        create_operator_assignment_sub_type lvalue, value, operator
       end
 
       private
@@ -123,7 +122,7 @@ module RipperRubyParser
         '&&': :op_asgn_and
       }.freeze
 
-      def create_operator_assignment_sub_type(lvalue, value, operator, original_value_type)
+      def create_operator_assignment_sub_type(lvalue, value, operator)
         case lvalue.sexp_type
         when :aref_field
           _, arr, arglist = lvalue

--- a/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
@@ -143,7 +143,7 @@ module RipperRubyParser
         old_type = args.sexp_type
         args = convert_arguments(process(args))
         args = nil if args == s(:args) && old_type == :params
-        make_iter(s(:call, nil, :lambda),
+        make_iter(s(:lambda),
                   args,
                   safe_unwrap_void_stmt(process(statements)))
       end

--- a/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
@@ -167,7 +167,10 @@ module RipperRubyParser
       end
 
       def handle_splat(splat)
-        if splat && splat != 0
+        if splat == 0
+          # Only relevant for Ruby < 2.6
+          [s(:excessed_comma)]
+        elsif splat
           [process(splat)]
         else
           []
@@ -209,7 +212,7 @@ module RipperRubyParser
       end
 
       def make_iter(call, args, stmt)
-        args.pop if args && args.last == s(:excessed_comma)
+        args[-1] = nil if args && args.last == s(:excessed_comma)
         args ||= 0
         if stmt.empty?
           s(:iter, call, args)

--- a/lib/ripper_ruby_parser/sexp_handlers/literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/literals.rb
@@ -260,11 +260,7 @@ module RipperRubyParser
       def handle_string_unescaping(content, delim)
         case delim
         when INTERPOLATING_HEREDOC
-          if extra_compatible
-            unescape(content).delete("\r")
-          else
-            unescape(content)
-          end
+          unescape(content)
         when *INTERPOLATING_STRINGS
           unescape(content)
         when INTERPOLATING_WORD_LIST

--- a/ripper_ruby_parser.gemspec
+++ b/ripper_ruby_parser.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('minitest', ['~> 5.6'])
   s.add_development_dependency('rake', ['~> 12.0'])
-  s.add_development_dependency('ruby_parser', ['~> 3.13.1'])
+  s.add_development_dependency('ruby_parser', ['~> 3.14.0'])
   s.add_development_dependency('simplecov')
 
   s.require_paths = ['lib']

--- a/test/end_to_end/comparison_test.rb
+++ b/test/end_to_end/comparison_test.rb
@@ -35,8 +35,8 @@ describe 'Using RipperRubyParser and RubyParser' do
       END
     end
 
-    it 'gives the same result with line numbers' do
-      _(program).must_be_parsed_as_before with_line_numbers: true
+    it 'gives the same result' do
+      _(program).must_be_parsed_as_before
     end
   end
 

--- a/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
@@ -604,46 +604,6 @@ describe RipperRubyParser::Parser do
                               :+,
                               s(:call, s(:call, nil, :baz), :qux, s(:call, nil, :quuz)))
       end
-
-      it 'works with a function call without parentheses in extra compatible mode' do
-        _('foo[bar] += baz qux').
-          must_be_parsed_as s(:op_asgn1,
-                              s(:call, nil, :foo),
-                              s(:array, s(:call, nil, :bar)),
-                              :+,
-                              s(:call, nil, :baz, s(:call, nil, :qux))),
-                            extra_compatible: true
-      end
-
-      it 'works with a function call with parentheses in extra compatible mode' do
-        _('foo[bar] += baz(qux)').
-          must_be_parsed_as s(:op_asgn1,
-                              s(:call, nil, :foo),
-                              s(:arglist, s(:call, nil, :bar)),
-                              :+,
-                              s(:call, nil, :baz, s(:call, nil, :qux))),
-                            extra_compatible: true
-      end
-
-      it 'works with a method call without parentheses in extra compatible mode' do
-        _('foo[bar] += baz.qux quuz').
-          must_be_parsed_as s(:op_asgn1,
-                              s(:call, nil, :foo),
-                              s(:array, s(:call, nil, :bar)),
-                              :+,
-                              s(:call, s(:call, nil, :baz), :qux, s(:call, nil, :quuz))),
-                            extra_compatible: true
-      end
-
-      it 'works with a method call with parentheses in extra compatible mode' do
-        _('foo[bar] += baz.qux(quuz)').
-          must_be_parsed_as s(:op_asgn1,
-                              s(:call, nil, :foo),
-                              s(:arglist, s(:call, nil, :bar)),
-                              :+,
-                              s(:call, s(:call, nil, :baz), :qux, s(:call, nil, :quuz))),
-                            extra_compatible: true
-      end
     end
   end
 end

--- a/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
@@ -95,11 +95,11 @@ describe RipperRubyParser::Parser do
                               s(:call, nil, :bar))
       end
 
-      it 'ignores a trailing comma in the block parameters' do
+      it 'handles a trailing comma in the block parameters' do
         _('foo do |bar, | end').
           must_be_parsed_as s(:iter,
                               s(:call, nil, :foo),
-                              s(:args, :bar))
+                              s(:args, :bar, nil))
       end
 
       it 'works with zero arguments' do
@@ -655,6 +655,24 @@ describe RipperRubyParser::Parser do
                               s(:block,
                                 s(:call, nil, :bar),
                                 s(:call, nil, :baz)))
+      end
+    end
+
+    describe 'for lambda keyword' do
+      it 'works in the simple case' do
+        _('lambda { |foo| bar }').
+          must_be_parsed_as s(:iter,
+                              s(:call, nil, :lambda),
+                              s(:args, :foo),
+                              s(:call, nil, :bar))
+      end
+
+      it 'works with trailing argument comma' do
+        _('lambda { |foo,| bar }').
+          must_be_parsed_as s(:iter,
+                              s(:call, nil, :lambda),
+                              s(:args, :foo, nil),
+                              s(:call, nil, :bar))
       end
     end
   end

--- a/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
@@ -611,7 +611,7 @@ describe RipperRubyParser::Parser do
       it 'works in the simple case' do
         _('->(foo) { bar }').
           must_be_parsed_as s(:iter,
-                              s(:call, nil, :lambda),
+                              s(:lambda),
                               s(:args, :foo),
                               s(:call, nil, :bar))
       end
@@ -619,7 +619,7 @@ describe RipperRubyParser::Parser do
       it 'works in the simple case without parentheses' do
         _('-> foo { bar }').
           must_be_parsed_as s(:iter,
-                              s(:call, nil, :lambda),
+                              s(:lambda),
                               s(:args, :foo),
                               s(:call, nil, :bar))
       end
@@ -627,7 +627,7 @@ describe RipperRubyParser::Parser do
       it 'works when there are zero arguments' do
         _('->() { bar }').
           must_be_parsed_as s(:iter,
-                              s(:call, nil, :lambda),
+                              s(:lambda),
                               s(:args),
                               s(:call, nil, :bar))
       end
@@ -635,7 +635,7 @@ describe RipperRubyParser::Parser do
       it 'works when there are no arguments' do
         _('-> { bar }').
           must_be_parsed_as s(:iter,
-                              s(:call, nil, :lambda),
+                              s(:lambda),
                               0,
                               s(:call, nil, :bar))
       end
@@ -643,14 +643,14 @@ describe RipperRubyParser::Parser do
       it 'works when there are no statements in the body' do
         _('->(foo) { }').
           must_be_parsed_as s(:iter,
-                              s(:call, nil, :lambda),
+                              s(:lambda),
                               s(:args, :foo))
       end
 
       it 'works when there are several statements in the body' do
         _('->(foo) { bar; baz }').
           must_be_parsed_as s(:iter,
-                              s(:call, nil, :lambda),
+                              s(:lambda),
                               s(:args, :foo),
                               s(:block,
                                 s(:call, nil, :bar),

--- a/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
@@ -1102,16 +1102,5 @@ describe RipperRubyParser::Parser do
           must_be_parsed_as s(:lit, 1000r)
       end
     end
-
-    describe 'in extra compatible mode' do
-      it 'converts \r to carriage returns in double-quoted strings' do
-        _('"foo\\rbar"').must_be_parsed_as s(:str, "foo\rbar"), extra_compatible: true
-      end
-
-      it 'removes \r from heredocs' do
-        _("<<FOO\nbar\\rbaz\\r\nFOO").
-          must_be_parsed_as s(:str, "barbaz\n"), extra_compatible: true
-      end
-    end
   end
 end

--- a/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
@@ -417,20 +417,5 @@ describe RipperRubyParser::Parser do
                                 s(:call, nil, :bar)))
       end
     end
-
-    describe 'when extra compatibility is turned on' do
-      it 'still treats block kwargs as lvars' do
-        _('def foo(**bar); baz { |**qux| bar; qux }; end').
-          must_be_parsed_as s(:defn, :foo,
-                              s(:args, :"**bar"),
-                              s(:iter,
-                                s(:call, nil, :baz),
-                                s(:args, :"**qux"),
-                                s(:block,
-                                  s(:lvar, :bar),
-                                  s(:lvar, :qux)))),
-                            extra_compatible: true
-      end
-    end
   end
 end

--- a/test/samples/lambdas.rb
+++ b/test/samples/lambdas.rb
@@ -1,0 +1,5 @@
+-> { }
+->() { }
+->(foo) { foo + bar }
+lambda { }
+lambda { |foo| foo + bar }

--- a/test/samples/misc.rb
+++ b/test/samples/misc.rb
@@ -276,3 +276,6 @@ end
 
 # Special symbols
 [:`, :|, :*, :&, :%, :'^', :-@, :+@, :'~@']
+
+# Blocks
+foo do |bar, | end

--- a/test/samples/strings.rb
+++ b/test/samples/strings.rb
@@ -49,6 +49,13 @@ FOO
 foo\rbar\tbaz\r
 FOO
 
+# Dedented heredocs
+foo = <<~BAR
+  baz
+  #{qux}
+  quuz
+BAR
+
 # Line continuation
 "foo\
 bar"


### PR DESCRIPTION
Makes output compatible with the recently-released version 3.14.0 of ruby_parser.

* Remove extra-compatible behavior since the default behavior now matches ruby_parser
* Parse stabby lambda as `s(:lambda ...)`
* Emit nil argument for block arguments with trailing comma