### PR TITLE
Improve line number handling for stabby lambdas

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
@@ -132,12 +132,16 @@ module RipperRubyParser
 
       def process_lambda(exp)
         _, args, statements = exp.shift 3
+
         old_type = args.sexp_type
         args = convert_arguments(process(args))
+        statements = process(statements)
+        line = args.line || statements.line
         args = nil if args == s(:args) && old_type == :params
-        make_iter(s(:lambda),
-                  args,
-                  safe_unwrap_void_stmt(process(statements)))
+        call = s(:lambda)
+        call.line = line
+
+        make_iter call, args, safe_unwrap_void_stmt(statements)
       end
 
       private

--- a/lib/ripper_ruby_parser/sexp_handlers/methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/methods.rb
@@ -98,6 +98,7 @@ module RipperRubyParser
       }.freeze
 
       def convert_arguments(args)
+        args.line ||= args.sexp_body.first&.line
         args.map! do |item|
           if item.is_a? Symbol
             item

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -79,10 +79,12 @@ module RipperRubyParser
 
     def process_stmts(exp)
       _, *statements = shift_all(exp)
-      statements = map_process_list_compact statements
+      statements = map_unwrap_begin_list map_process_list statements
+      line = statements.first.line
+      statements = reject_void_stmt statements
       case statements.count
       when 0
-        s(:void_stmt)
+        s(:void_stmt).line(line)
       when 1
         statements.first
       else

--- a/ripper_ruby_parser.gemspec
+++ b/ripper_ruby_parser.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("minitest", ["~> 5.6"])
   s.add_development_dependency("rake", ["~> 13.0"])
-  s.add_development_dependency("ruby_parser", ["~> 3.14.0"])
+  s.add_development_dependency("ruby_parser", ["~> 3.14.1"])
   s.add_development_dependency("simplecov")
 
   s.require_paths = ["lib"]

--- a/test/end_to_end/comparison_test.rb
+++ b/test/end_to_end/comparison_test.rb
@@ -35,8 +35,8 @@ describe "Using RipperRubyParser and RubyParser" do
       RUBY
     end
 
-    it "gives the same result" do
-      _(program).must_be_parsed_as_before
+    it "gives the same result with line numbers" do
+      _(program).must_be_parsed_as_before with_line_numbers: true
     end
   end
 

--- a/test/end_to_end/comparison_test.rb
+++ b/test/end_to_end/comparison_test.rb
@@ -63,8 +63,8 @@ describe "Using RipperRubyParser and RubyParser" do
       RUBY
     end
 
-    it "gives the same result" do
-      _(program).must_be_parsed_as_before
+    it "gives the same result with line numbers" do
+      _(program).must_be_parsed_as_before with_line_numbers: true
     end
   end
 
@@ -87,8 +87,8 @@ describe "Using RipperRubyParser and RubyParser" do
       RUBY
     end
 
-    it "gives the same result" do
-      _(program).must_be_parsed_as_before
+    it "gives the same result with line numbers" do
+      _(program).must_be_parsed_as_before with_line_numbers: true
     end
   end
 

--- a/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
@@ -656,6 +656,22 @@ describe RipperRubyParser::Parser do
                                  s(:call, nil, :bar),
                                  s(:call, nil, :baz)))
       end
+
+      it "sets line numbers correctly for lambdas with empty bodies" do
+        _("->(foo) { }\nbar")
+          .must_be_parsed_as s(:block,
+                               s(:iter, s(:lambda).line(1), s(:args, :foo).line(1)).line(1),
+                               s(:call, nil, :bar).line(2)).line(1),
+                             with_line_numbers: true
+      end
+
+      it "sets line numbers correctly for empty lambdas" do
+        _("->() { }\nfoo")
+          .must_be_parsed_as s(:block,
+                               s(:iter, s(:lambda).line(1), s(:args).line(1)).line(1),
+                               s(:call, nil, :foo).line(2)).line(1),
+                             with_line_numbers: true
+      end
     end
 
     describe "for lambda keyword" do


### PR DESCRIPTION
* Depend (in development) on ruby_parser 3.14.1 which has improved line number handling.
* Compare line numbers in more end-to-end tests.
* Fix line numbers for stabby lambdas without arguments and/or body statements.
