### PR TITLE
Add preliminary support for Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 bundler_args: --without local_development
 rvm:
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.4
+  - 2.5
+  - 2.6
   - ruby-head
 matrix:
   allow_failures:

--- a/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
@@ -285,12 +285,23 @@ describe RipperRubyParser::Parser do
       end
 
       it "works with a rescue modifier" do
+        expected = if RUBY_VERSION < "2.7.0"
+                     s(:rescue,
+                       s(:masgn,
+                         s(:array, s(:lasgn, :foo), s(:lasgn, :bar)),
+                         s(:to_ary, s(:call, nil, :baz))),
+                       s(:resbody, s(:array), s(:call, nil, :qux)))
+                   else
+                     s(:masgn,
+                       s(:array, s(:lasgn, :foo), s(:lasgn, :bar)),
+                       s(:to_ary,
+                         s(:rescue,
+                           s(:call, nil, :baz),
+                           s(:resbody, s(:array), s(:call, nil, :qux)))))
+                   end
+
         _("foo, bar = baz rescue qux")
-          .must_be_parsed_as s(:rescue,
-                               s(:masgn,
-                                 s(:array, s(:lasgn, :foo), s(:lasgn, :bar)),
-                                 s(:to_ary, s(:call, nil, :baz))),
-                               s(:resbody, s(:array), s(:call, nil, :qux)))
+          .must_be_parsed_as expected
       end
 
       it "works the same number of items on each side" do


### PR DESCRIPTION
This makes the tests succeed on CRuby 2.7.0-preview2.

* Precedence of rescue modifier w.r.t. multiple assignment has changed (https://bugs.ruby-lang.org/issues/8239).
* No further checks for results of parsing 2.7-specific constructs was added.