### PR TITLE
Don't run tests on Ruby head in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, "3.0", head]
+        ruby: [2.5, 2.6, 2.7, "3.0"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The test run succeeded on head before, but head is in fact not a stable target.