### PR TITLE
Improve non-interpolating string handling

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/string_literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/string_literals.rb
@@ -243,11 +243,11 @@ module RipperRubyParser
         when INTERPOLATING_WORD_LIST
           unescape_wordlist_word(content)
         when *NON_INTERPOLATING_STRINGS
-          simple_unescape(content)
+          simple_unescape(content, delim)
         when *REGEXP_LITERALS
           unescape_regexp(content)
         when NON_INTERPOLATING_WORD_LIST
-          simple_unescape_wordlist_word(content)
+          simple_unescape_wordlist_word(content, delim)
         else
           content
         end

--- a/lib/ripper_ruby_parser/unescape.rb
+++ b/lib/ripper_ruby_parser/unescape.rb
@@ -37,25 +37,34 @@ module RipperRubyParser
     SINGLE_LETTER_ESCAPES_REGEXP =
       Regexp.new("^[#{SINGLE_LETTER_ESCAPES.keys.join}]$")
 
-    def simple_unescape(string)
+    DELIMITER_PAIRS = {
+      "(" => "()",
+      "<" => "<>",
+      "[" => "[]",
+      "{" => "{}"
+    }.freeze
+
+    def simple_unescape(string, delimiter)
+      delimiters = delimiter_regexp_pattern(delimiter)
       string.gsub(/
                   \\ # a backslash
                   (  # followed by a
-                   '   | # single quote or
-                   \\    # backslash
+                    #{delimiters} | # delimiter or
+                    \\              # backslash
                   )/x) do
                     Regexp.last_match[1]
                   end
     end
 
-    def simple_unescape_wordlist_word(string)
+    def simple_unescape_wordlist_word(string, delimiter)
+      delimiters = delimiter_regexp_pattern(delimiter)
       string.gsub(/
                   \\ # a backslash
                   (  # followed by a
-                    '   | # single quote or
-                    \\  | # backslash or
-                    [ ] | # space or
-                    \n    # newline
+                    #{delimiters} | # delimiter or
+                    \\            | # backslash or
+                    [ ]           | # space or
+                    \n              # newline
                   )
                   /x) do
                     Regexp.last_match[1]
@@ -163,6 +172,12 @@ module RipperRubyParser
 
     def meta(val)
       val | 0b1000_0000
+    end
+
+    def delimiter_regexp_pattern(delimiter)
+      delimiter = delimiter[-1]
+      delimiters = DELIMITER_PAIRS.fetch(delimiter, delimiter)
+      delimiters.each_char.map { |it| Regexp.escape it }.join(" | ")
     end
   end
 end

--- a/test/ripper_ruby_parser/sexp_handlers/string_literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/string_literals_test.rb
@@ -195,6 +195,17 @@ describe RipperRubyParser::Parser do
           .must_be_parsed_as s(:str, "foo\\\nbar")
       end
 
+      # NOTE: This behavior is odd since Ruby removes the carriage return
+      it "keeps carriage return/line feed combinations" do
+        _("\"bar\r\n\"")
+          .must_be_parsed_as s(:str, "bar\r\n")
+      end
+
+      it "keeps carriage returns without line feeds" do
+        _("\"bar\rbaz\r\n\"")
+          .must_be_parsed_as s(:str, "bar\rbaz\r\n")
+      end
+
       describe "with double-quoted strings with escape sequences" do
         it "works for strings with escape sequences" do
           _('"\\n"')
@@ -609,6 +620,17 @@ describe RipperRubyParser::Parser do
 
         it 'converts \r to carriage returns' do
           _("<<FOO\nbar\\rbaz\\r\nFOO")
+            .must_be_parsed_as s(:str, "bar\rbaz\r\n")
+        end
+
+        # NOTE: This behavior is odd since Ruby removes the carriage return
+        it "keeps carriage return/line feed combinations" do
+          _("<<FOO\nbar\r\nFOO")
+            .must_be_parsed_as s(:str, "bar\r\n")
+        end
+
+        it "keeps carriage returns without line feeds" do
+          _("<<FOO\nbar\rbaz\r\nFOO")
             .must_be_parsed_as s(:str, "bar\rbaz\r\n")
         end
 

--- a/test/ripper_ruby_parser/sexp_handlers/string_literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/string_literals_test.rb
@@ -607,11 +607,6 @@ describe RipperRubyParser::Parser do
             .must_be_parsed_as s(:str, "  bar\n")
         end
 
-        it "works for the automatically outdenting case" do
-          _("  <<~FOO\n  bar\n  FOO")
-            .must_be_parsed_as s(:str, "bar\n")
-        end
-
         it "works for escape sequences" do
           _("<<FOO\nbar\\tbaz\nFOO")
             .must_be_parsed_as s(:str, "bar\tbaz\n")
@@ -635,11 +630,6 @@ describe RipperRubyParser::Parser do
         it "does not unescape with indentable single quoted version" do
           _("<<-'FOO'\n  bar\\tbaz\n  FOO")
             .must_be_parsed_as s(:str, "  bar\\tbaz\n")
-        end
-
-        it "does not unescape the automatically outdenting single quoted version" do
-          _("<<~'FOO'\n  bar\\tbaz\n  FOO")
-            .must_be_parsed_as s(:str, "bar\\tbaz\n")
         end
 
         it "handles line continuation" do
@@ -671,13 +661,6 @@ describe RipperRubyParser::Parser do
                                  s(:str, " baz\n"))
         end
 
-        it "handles interpolation with subsequent whitespace for dedented heredocs" do
-          _("<<~FOO\n  \#{bar} baz\nFOO")
-            .must_be_parsed_as s(:dstr, "",
-                                 s(:evstr, s(:call, nil, :bar)),
-                                 s(:str, " baz\n"))
-        end
-
         it "handles line continuation after interpolation" do
           _("<<FOO\n\#{bar}\nbaz\\\nqux\nFOO")
             .must_be_parsed_as s(:dstr, "",
@@ -690,6 +673,25 @@ describe RipperRubyParser::Parser do
             .must_be_parsed_as s(:dstr, "",
                                  s(:evstr, s(:call, nil, :bar)),
                                  s(:str, "\nbazqux\n"))
+        end
+      end
+
+      describe "for squiggly heredocs" do
+        it "works for the simple case" do
+          _("  <<~FOO\n  bar\n  FOO")
+            .must_be_parsed_as s(:str, "bar\n")
+        end
+
+        it "does not unescape the single quoted version" do
+          _("<<~'FOO'\n  bar\\tbaz\n  FOO")
+            .must_be_parsed_as s(:str, "bar\\tbaz\n")
+        end
+
+        it "handles interpolation with subsequent whitespace" do
+          _("<<~FOO\n  \#{bar} baz\nFOO")
+            .must_be_parsed_as s(:dstr, "",
+                                 s(:evstr, s(:call, nil, :bar)),
+                                 s(:str, " baz\n"))
         end
       end
     end

--- a/test/ripper_ruby_parser/sexp_handlers/string_literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/string_literals_test.rb
@@ -602,11 +602,6 @@ describe RipperRubyParser::Parser do
             .must_be_parsed_as s(:str, "bar\nbaz\n")
         end
 
-        it "works for the indentable case" do
-          _("<<-FOO\n  bar\n  FOO")
-            .must_be_parsed_as s(:str, "  bar\n")
-        end
-
         it "works for escape sequences" do
           _("<<FOO\nbar\\tbaz\nFOO")
             .must_be_parsed_as s(:str, "bar\tbaz\n")
@@ -625,11 +620,6 @@ describe RipperRubyParser::Parser do
         it "works with multiple lines with the single quoted version" do
           _("<<'FOO'\nbar\nbaz\nFOO")
             .must_be_parsed_as s(:str, "bar\nbaz\n")
-        end
-
-        it "does not unescape with indentable single quoted version" do
-          _("<<-'FOO'\n  bar\\tbaz\n  FOO")
-            .must_be_parsed_as s(:str, "  bar\\tbaz\n")
         end
 
         it "handles line continuation" do
@@ -667,8 +657,20 @@ describe RipperRubyParser::Parser do
                                  s(:evstr, s(:call, nil, :bar)),
                                  s(:str, "\nbazqux\n"))
         end
+      end
 
-        it "handles line continuation after interpolation for the indentable case" do
+      describe "for indentable heredocs" do
+        it "works for the simple case" do
+          _("<<-FOO\n  bar\n  FOO")
+            .must_be_parsed_as s(:str, "  bar\n")
+        end
+
+        it "does not unescape the single quoted version" do
+          _("<<-'FOO'\n  bar\\tbaz\n  FOO")
+            .must_be_parsed_as s(:str, "  bar\\tbaz\n")
+        end
+
+        it "handles line continuation after interpolation" do
           _("<<-FOO\n\#{bar}\nbaz\\\nqux\nFOO")
             .must_be_parsed_as s(:dstr, "",
                                  s(:evstr, s(:call, nil, :bar)),

--- a/test/ripper_ruby_parser/sexp_handlers/string_literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/string_literals_test.rb
@@ -509,9 +509,49 @@ describe RipperRubyParser::Parser do
             .must_be_parsed_as s(:str, "bar")
         end
 
-        it "does not handle for escape sequences" do
-          _('%q[foo\\nbar]')
-            .must_be_parsed_as s(:str, 'foo\nbar')
+        it "does not unescape escape sequences" do
+          _("%q[foo\\nbar]")
+            .must_be_parsed_as s(:str, "foo\\nbar")
+        end
+
+        it "does not unescape invalid escape sequences" do
+          _("%q[foo\\ubar]")
+            .must_be_parsed_as s(:str, "foo\\ubar")
+        end
+
+        it "handles escaped delimiters for brackets" do
+          _("%q[foo\\[bar\\]baz]")
+            .must_be_parsed_as s(:str, "foo[bar]baz")
+        end
+
+        it "handles escaped delimiters for parentheses" do
+          _("%q(foo\\(bar\\)baz)")
+            .must_be_parsed_as s(:str, "foo(bar)baz")
+        end
+
+        it "handles escaped delimiters for braces" do
+          _("%q{foo\\{bar\\}baz}")
+            .must_be_parsed_as s(:str, "foo{bar}baz")
+        end
+
+        it "handles escaped delimiters for angle brackets" do
+          _("%q<foo\\<bar\\>baz>")
+            .must_be_parsed_as s(:str, "foo<bar>baz")
+        end
+
+        it "handles escaped delimiters for slashes" do
+          _("%q/foo\\/bar]baz/")
+            .must_be_parsed_as s(:str, "foo/bar]baz")
+        end
+
+        it "does not unescape unused delimiters" do
+          _("%q[foo\\{\\}\\<\\>\\(\\)baz]")
+            .must_be_parsed_as s(:str, "foo\\{\\}\\<\\>\\(\\)baz")
+        end
+
+        it "does not unescape escape sequences for single quotes" do
+          _("%q[foo\\'bar]")
+            .must_be_parsed_as s(:str, "foo\\'bar")
         end
 
         it "works for multi-line strings" do
@@ -739,6 +779,41 @@ describe RipperRubyParser::Parser do
       it "handles escaped spaces" do
         _('%w(foo bar\ baz)')
           .must_be_parsed_as s(:array, s(:str, "foo"), s(:str, "bar baz"))
+      end
+
+      it "handles escaped delimiters for brackets" do
+        _("%w[foo \\[bar\\] baz]")
+          .must_be_parsed_as s(:array, s(:str, "foo"), s(:str, "[bar]"), s(:str, "baz"))
+      end
+
+      it "handles escaped delimiters for parentheses" do
+        _("%w(foo\\(bar\\)baz)")
+          .must_be_parsed_as s(:array, s(:str, "foo(bar)baz"))
+      end
+
+      it "handles escaped delimiters for braces" do
+        _("%w{foo\\{bar\\}baz}")
+          .must_be_parsed_as s(:array, s(:str, "foo{bar}baz"))
+      end
+
+      it "handles escaped delimiters for angle brackets" do
+        _("%w<foo\\<bar\\>baz>")
+          .must_be_parsed_as s(:array, s(:str, "foo<bar>baz"))
+      end
+
+      it "handles escaped delimiters for slashes" do
+        _("%w/foo\\/bar]baz/")
+          .must_be_parsed_as s(:array, s(:str, "foo/bar]baz"))
+      end
+
+      it "does not unescape unused delimiters" do
+        _("%w[foo\\{\\}\\<\\>\\(\\)baz]")
+          .must_be_parsed_as s(:array, s(:str, "foo\\{\\}\\<\\>\\(\\)baz"))
+      end
+
+      it "does not unescape escape sequences for single quotes" do
+        _("%w[foo\\'bar]")
+          .must_be_parsed_as s(:array, s(:str, "foo\\'bar"))
       end
     end
 

--- a/test/samples/strings.rb
+++ b/test/samples/strings.rb
@@ -105,8 +105,24 @@ bar baz]
 %q[fooc\
 bar]
 
+%q[foo\'bar]
+
+%q[foo[bar]baz]
+
+%q[foo\[bar\]baz]
+
+%q[foo\{{\((\<<bar\]baz]
+
 %w[food\
 bar baz]
+
+%w[foo\'bar]
+
+%w[foo [bar] baz]
+
+%w[foo \[bar\] baz]
+
+%w[foo \{{ \(( \<< bar\] baz]
 
 %i[fooe\
 bar baz]


### PR DESCRIPTION
- Move squiggly heredoc tests to their own section
- Move indentable heredoc tests to their own section
- Add tests describing current carriage return/line feed handling
- Fix escape sequence handling in non-interpolating strings and word lists
