### PR TITLE
Support argument forwarding

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/method_calls.rb
@@ -26,7 +26,11 @@ module RipperRubyParser
         _, call, parens = exp.shift 3
         call = process(call)
         parens = process(parens)
-        call.push(*parens.sexp_body)
+        if parens.sexp_type == :forward_args
+          call.push(parens)
+        else
+          call.push(*parens.sexp_body)
+        end
       end
 
       # Handle implied hashes, such as at the end of argument lists.

--- a/lib/ripper_ruby_parser/sexp_handlers/methods.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/methods.rb
@@ -72,6 +72,11 @@ module RipperRubyParser
         s(:alias, process(left), process(right))
       end
 
+      def process_args_forward(exp)
+        _ = exp.shift
+        s(:forward_args)
+      end
+
       private
 
       def in_method

--- a/ripper_ruby_parser.gemspec
+++ b/ripper_ruby_parser.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 1.18.0"
   spec.add_development_dependency "rubocop-minitest", "~> 0.14.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.11.0"
-  spec.add_development_dependency "ruby_parser", "~> 3.16.0"
+  spec.add_development_dependency "ruby_parser", "~> 3.17.0"
   # For testing, require sexp_processor 4.13, 4.14 or 4.15 so its test cases
   # match version 3.14.0 of ruby_parser.
   spec.add_development_dependency "sexp_processor", [">= 4.13.0", "< 4.16"]

--- a/ripper_ruby_parser.gemspec
+++ b/ripper_ruby_parser.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sexp_processor", "~> 4.10"
 
   spec.add_development_dependency "minitest", "~> 5.6"
+  spec.add_development_dependency "minitest-focus", "~> 1.3.1"
   spec.add_development_dependency "pry", "~> 0.14.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"

--- a/test/end_to_end/samples_comparison_test.rb
+++ b/test/end_to_end/samples_comparison_test.rb
@@ -7,6 +7,7 @@ describe "Using RipperRubyParser and RubyParser" do
   Dir.glob(File.expand_path("../samples/*.rb", File.dirname(__FILE__))).each do |file|
     next if RUBY_VERSION < "2.6.0" && file.match?(/_26.rb\Z/)
     next if RUBY_VERSION < "2.7.0" && file.match?(/_27.rb\Z/)
+    next if RUBY_VERSION < "3.0.0" && file.match?(/_30.rb\Z/)
 
     it "gives the same result for #{file}" do
       program = File.read file

--- a/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
@@ -213,6 +213,16 @@ describe RipperRubyParser::Parser do
                                s(:nil))
       end
 
+      it "works with argument forwarding" do
+        if RUBY_VERSION < "2.7.0"
+          skip "This Ruby version does not support argument forwarding"
+        end
+        _("def foo(...); bar(...); end")
+          .must_be_parsed_as s(:defn, :foo,
+                               s(:args, s(:forward_args)),
+                               s(:call, nil, :bar, s(:forward_args)))
+      end
+
       it "assigns correct line numbers when the body is empty" do
         _("def bar\nend")
           .must_be_parsed_as s(:defn,

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -5,4 +5,7 @@
 ..foo
 
 # Argument forwarding
-def foo(...); bar(...); end
+def foo(...)
+  bar(...)
+  bar(qux, ...)
+end

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -3,3 +3,6 @@
 # Beginless ranges
 ..1
 ..foo
+
+# Argument forwarding
+def foo(...); bar(...); end

--- a/test/samples/ruby_30.rb
+++ b/test/samples/ruby_30.rb
@@ -1,0 +1,7 @@
+# Samples that need Ruby 3.0 or higher
+
+# Argument forwarding with leading argument
+def foo(bar, ...)
+  baz bar
+  qux(...)
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ SimpleCov.start do
 end
 
 require "minitest/autorun"
+require "minitest/focus"
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 


### PR DESCRIPTION
- Bump ruby_parser development dependency
- Add tests for argument forwarding
- Add minitest-focus dependency
- Handle Ruby 2.7 style args forwarding
- Add Ruby 3.0 argument forwarding sample
- Extend Ruby 2.7 argument forwarding sample
