### PR TITLE
Add tentative support for numbered parameters

### DIFF
--- a/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
@@ -217,9 +217,19 @@ module RipperRubyParser
         end
       end
 
+      LVAR_MATCHER = Sexp::Matcher.new(:lvar, Sexp._)
+      NUMBERED_PARAMS = (1..9).map { |it| :"_#{it}" }.freeze
+
       def make_iter(call, args, stmt)
         args[-1] = nil if args && args.last == s(:excessed_comma)
+
+        if args.nil? && RUBY_VERSION >= "2.7.0"
+          lvar_names = (LVAR_MATCHER / stmt).map { |it| it[1] }
+          args = (NUMBERED_PARAMS & lvar_names).length
+        end
+
         args ||= 0
+
         if stmt.empty?
           s(:iter, call, args)
         else

--- a/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
@@ -223,18 +223,22 @@ module RipperRubyParser
       def make_iter(call, args, stmt)
         args[-1] = nil if args && args.last == s(:excessed_comma)
 
-        if args.nil? && RUBY_VERSION >= "2.7.0"
-          lvar_names = (LVAR_MATCHER / stmt).map { |it| it[1] }
-          args = (NUMBERED_PARAMS & lvar_names).length
-        end
-
-        args ||= 0
+        args ||= if RUBY_VERSION >= "2.7.0"
+                   count_numbered_lvars(stmt)
+                 else
+                   0
+                 end
 
         if stmt.empty?
           s(:iter, call, args)
         else
           s(:iter, call, args, stmt)
         end
+      end
+
+      def count_numbered_lvars(stmt)
+        lvar_names = (LVAR_MATCHER / stmt).map { |it| it[1] }
+        (NUMBERED_PARAMS & lvar_names).length
       end
     end
   end

--- a/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
@@ -219,6 +219,31 @@ describe RipperRubyParser::Parser do
                                s(:args, :bar, :baz,
                                  s(:shadow, :qux)))
       end
+
+      it "works with numbered parameters" do
+        if RUBY_VERSION < "2.7.0"
+          skip "This Ruby version does not support numbered parameters"
+        end
+        _("foo do _1.bar(_2); end")
+          .must_be_parsed_as \
+            s(:iter,
+              s(:call, nil, :foo),
+              2,
+              s(:call, s(:lvar, :_1), :bar, s(:lvar, :_2)))
+      end
+
+      it "parses code that looks like numbered parameters correctly on older rubies" do
+        if RUBY_VERSION >= "2.7.0"
+          skip "This Ruby version interprets this code as numbered parameters"
+        end
+        _("_1 = 1; foo { bar _1, _2 }")
+          .must_be_parsed_as \
+            s(:block,
+              s(:lasgn, :_1, s(:lit, 1)),
+              s(:iter,
+                s(:call, nil, :foo), 0,
+                s(:call, nil, :bar, s(:lvar, :_1), s(:call, nil, :_2))))
+      end
     end
 
     describe "for begin" do

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -46,3 +46,8 @@ end
 # One-line pattern matching (experimental)
 1 in foo
 2 in bar => baz
+
+# Numbered block parameters
+# NOTE: Not yet implemented in ruby_parser
+# foos.each do _1.bar; end
+# foos.each { _1.bar }


### PR DESCRIPTION
This adds support for numbered parameters, but ruby_parser doesn't support them yet, so the resulting AST may change in the future.
