### PR TITLE
Drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, "3.0"]
+        ruby: [2.6, 2.7, "3.0"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/bundle/**/*'
   NewCops: enable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 # Make BeginEndAlignment behavior match EndAlignment
 Layout/BeginEndAlignment:

--- a/lib/ripper_ruby_parser/sexp_handlers/literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/literals.rb
@@ -7,7 +7,7 @@ module RipperRubyParser
       # character literals
       def process_at_CHAR(exp)
         _, val, pos = exp.shift 3
-        with_position(pos, s(:str, fix_encoding(unescape(val[1..-1]))))
+        with_position(pos, s(:str, fix_encoding(unescape(val[1..]))))
       end
 
       def process_array(exp)

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -195,7 +195,7 @@ module RipperRubyParser
 
     def process_at_backref(exp)
       _, str, pos = exp.shift 3
-      name = str[1..-1]
+      name = str[1..]
       with_position pos do
         if /[0-9]/.match?(name)
           s(:nth_ref, name.to_i)

--- a/lib/ripper_ruby_parser/unescape.rb
+++ b/lib/ripper_ruby_parser/unescape.rb
@@ -131,7 +131,7 @@ module RipperRubyParser
     end
 
     def unescape_hex_char(bare)
-      hex_to_char(bare[1..-1])
+      hex_to_char(bare[1..])
     end
 
     def unescape_unicode_char(bare)

--- a/ripper_ruby_parser.gemspec
+++ b/ripper_ruby_parser.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "http://www.github.com/mvz/ripper_ruby_parser"
   spec.license = "MIT"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/ripper_ruby_parser"

--- a/test/end_to_end/samples_comparison_test.rb
+++ b/test/end_to_end/samples_comparison_test.rb
@@ -7,7 +7,6 @@ describe "Using RipperRubyParser and RubyParser" do
   make_my_diffs_pretty!
 
   Dir.glob(File.expand_path("../samples/*.rb", File.dirname(__FILE__))).each do |file|
-    next if RUBY_VERSION < "2.6.0" && file.match?(/_26.rb\Z/)
     next if RUBY_VERSION < "2.7.0" && file.match?(/_27.rb\Z/)
     next if RUBY_VERSION < "3.0.0" && file.match?(/_30.rb\Z/)
 

--- a/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
+++ b/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
@@ -14,12 +14,11 @@ describe RipperRubyParser::CommentingRipperParser do
 
   describe "handling comments" do
     # Handle different results for dynamic symbol strings. This was changed in
-    # Ruby 2.7.0, and backported to 2.6.3 and 2.5.8.
+    # Ruby 2.7.0, and backported to 2.6.3
     #
     # See https://bugs.ruby-lang.org/issues/15670
     let(:dsym_string_type) do
-      if RUBY_VERSION >= "2.6.3" ||
-          RUBY_VERSION < "2.6.0" && RUBY_VERSION >= "2.5.8"
+      if RUBY_VERSION >= "2.6.3"
         :string_content
       else
         :xstring

--- a/test/ripper_ruby_parser/sexp_handlers/operators_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/operators_test.rb
@@ -236,7 +236,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "handles endless range literals" do
-        skip "This Ruby version does not support endless ranges" if RUBY_VERSION < "2.6.0"
         _("1..")
           .must_be_parsed_as s(:dot2, s(:lit, 1), nil)
       end
@@ -302,7 +301,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "handles endless range literals" do
-        skip "This Ruby version does not support endless ranges" if RUBY_VERSION < "2.6.0"
         _("1...")
           .must_be_parsed_as s(:dot3, s(:lit, 1), nil)
       end

--- a/test/samples/misc.rb
+++ b/test/samples/misc.rb
@@ -293,3 +293,9 @@ foo do |bar, baz; qux, quuz| end
 if defined? foo
   bar
 end
+
+# Endless ranges
+1..
+
+foobar = 2
+foobar..

--- a/test/samples/ruby_26.rb
+++ b/test/samples/ruby_26.rb
@@ -1,5 +1,0 @@
-# Endless ranges
-1..
-
-foo = 2
-foo..


### PR DESCRIPTION
- Require at least Ruby 2.6 in the gemspec
- Update RuboCop configuration and fix new offenses
- Remove Ruby version checks that are no longer relevant
