### PR TITLE
Add support for pattern matching

### DIFF
--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -10,6 +10,39 @@ def foo(...)
   bar(qux, ...)
 end
 
+# Pattern matching (experimental)
+
+## NOTE: ruby_parser treats matched variables as methods in this case
+# case foo
+#   in blub
+#   p blub
+# end
+
+## NOTE: ruby_parser treats matched variables as methods in this case
+# case foo
+#   in [bar, baz]
+#   quz = bar + baz
+# end
+
+## NOTE: ruby_parser treats matched variables as methods in this case
+# case foo
+#   in [bar, baz]
+#   quz = bar + baz
+#   in blub
+#   p blub
+# end
+
+## NOTE: ruby_parser treats matched variables as methods in this case
+# case foo
+#   in { bar: [baz, qux] }
+#   quz = bar(baz) + baz
+# end
+
+case foo
+  in { bar: }
+  quz = quuz(bar)
+end
+
 # One-line pattern matching (experimental)
 1 in foo
 2 in bar => baz


### PR DESCRIPTION
This adds support for pattern matching with 'in' inside case statements. The result does not fully match ruby_parser, since ruby_parser does not currently recognize the matched variables as variables.