### PR TITLE
Improve Ruby 3.0 samples

### DIFF
--- a/test/samples/ruby_30.rb
+++ b/test/samples/ruby_30.rb
@@ -1,7 +1,9 @@
 # Samples that need Ruby 3.0 or higher
 
 # Right-ward assignment
-42 => foo
+def foo
+  42 => bar
+end
 
 # Argument forwarding with leading argument
 def foo(bar, ...)
@@ -10,7 +12,7 @@ def foo(bar, ...)
 end
 
 # Endless methods
-def foo # Avoid comment attaching to next method
+def foo # FIXME: Avoid comment attaching to next method
 end
 
 def foo(bar) = baz(bar)


### PR DESCRIPTION
- Isolate rightward assignment sample
- Mark comment attachment avoidance hack as to be fixed
