### PR TITLE
Support new Ruby 3.1 syntax features

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 254
+  Max: 263
 
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 Metrics/MethodLength:

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -35,7 +35,16 @@ module RipperRubyParser
     end
 
     def on_begin(*args)
-      commentize("begin", super)
+      result = super
+
+      # Some begin blocks are not created by the 'begin' keyword. Skip
+      # commenting for those kinds of blocks.
+      (_, kw,), = @comment_stack.last
+      if kw == "begin"
+        commentize("begin", result)
+      else
+        result
+      end
     end
 
     def on_void_stmt

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -35,7 +35,7 @@ module RipperRubyParser
     end
 
     def on_begin(*args)
-      commentize(:begin, super)
+      commentize("begin", super)
     end
 
     def on_void_stmt
@@ -72,23 +72,23 @@ module RipperRubyParser
     end
 
     def on_module(*args)
-      commentize(:module, super)
+      commentize("module", super)
     end
 
     def on_class(*args)
-      commentize(:class, super)
+      commentize("class", super)
     end
 
     def on_sclass(*args)
-      commentize(:class, super)
+      commentize("class", super)
     end
 
     def on_def(*args)
-      commentize(:def, super)
+      commentize("def", super)
     end
 
     def on_defs(*args)
-      commentize(:def, super)
+      commentize("def", super)
     end
 
     def on_args_new
@@ -300,11 +300,11 @@ module RipperRubyParser
     end
 
     def on_BEGIN(*args)
-      commentize(:BEGIN, super)
+      commentize("BEGIN", super)
     end
 
     def on_END(*args)
-      commentize(:END, super)
+      commentize("END", super)
     end
 
     def on_parse_error(message)
@@ -327,8 +327,12 @@ module RipperRubyParser
       raise SyntaxError, message
     end
 
-    def commentize(_name, exp)
-      (_, _kw, loc), comment = @comment_stack.pop
+    def commentize(name, exp)
+      (_, kw, loc), comment = @comment_stack.pop
+      if kw != name
+        raise "Comment subject mismatch: expected #{name.inspect}, found #{kw.inspect}"
+      end
+
       @comment = ""
       exp.push loc
       [:comment, comment, exp]

--- a/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
@@ -88,7 +88,7 @@ module RipperRubyParser
       def process_aryptn(exp)
         _, _, body, rest, = exp.shift 5
 
-        elements = body.map { |it| process(it) }
+        elements = body.map { |it| unwrap_begin process(it) }
         if rest
           rest_var = handle_pattern(rest)
           elements << convert_marked_argument(s(:splat, rest_var))

--- a/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
@@ -623,6 +623,17 @@ describe RipperRubyParser::Parser do
                                  s(:array_pat, nil, s(:call, nil, :baz)),
                                  s(:call, nil, :qux, s(:call, nil, :baz))), nil)
       end
+
+      it "works with an in clause with carets with instance, class and global variables" do
+        skip "This Ruby version does not support caret + parens" if RUBY_VERSION < "3.1.0"
+        _("case foo; in [^@a, ^$b, ^@@c]; qux baz; end")
+          .must_be_parsed_as s(:case,
+                               s(:call, nil, :foo),
+                               s(:in,
+                                 s(:array_pat, nil,
+                                   s(:ivar, :@a), s(:gvar, :$b), s(:cvar, :@@c)),
+                                 s(:call, nil, :qux, s(:call, nil, :baz))), nil)
+      end
     end
 
     describe "for one-line pattern matching" do

--- a/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
@@ -604,6 +604,25 @@ describe RipperRubyParser::Parser do
                                  s(:array_pat, nil, s(:lasgn, :baz, s(:const, :String))),
                                  s(:call, nil, :qux, s(:lvar, :baz))), nil)
       end
+
+      it "works with an in clause with caret" do
+        _("case foo; in [^baz]; qux baz; end")
+          .must_be_parsed_as s(:case,
+                               s(:call, nil, :foo),
+                               s(:in,
+                                 s(:array_pat, nil, s(:lvar, :baz)),
+                                 s(:call, nil, :qux, s(:call, nil, :baz))), nil)
+      end
+
+      it "works with an in clause with caret and parentheses" do
+        skip "This Ruby version does not support caret + parens" if RUBY_VERSION < "3.1.0"
+        _("case foo; in [^(baz)]; qux baz; end")
+          .must_be_parsed_as s(:case,
+                               s(:call, nil, :foo),
+                               s(:in,
+                                 s(:array_pat, nil, s(:call, nil, :baz)),
+                                 s(:call, nil, :qux, s(:call, nil, :baz))), nil)
+      end
     end
 
     describe "for one-line pattern matching" do

--- a/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
@@ -111,6 +111,14 @@ describe RipperRubyParser::Parser do
                                s(:lit, :baz), s(:call, nil, :qux),
                                s(:kwsplat, s(:call, nil, :quux)))
       end
+
+      it "works for shorthand hash syntax" do
+        if RUBY_VERSION < "3.1.0"
+          skip "This Ruby version does not support shorthand hash syntax"
+        end
+        _("{ foo: }")
+          .must_be_parsed_as s(:hash, s(:lit, :foo), nil)
+      end
     end
 
     describe "for number literals" do

--- a/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
@@ -134,6 +134,17 @@ describe RipperRubyParser::Parser do
                                s(:nil))
       end
 
+      it "works for a bare block parameter" do
+        if RUBY_VERSION < "3.1.0"
+          skip "This Ruby version does not support bare block parameters"
+        end
+        _("def foo &; end")
+          .must_be_parsed_as s(:defn,
+                               :foo,
+                               s(:args, :&),
+                               s(:nil))
+      end
+
       it "works with a default value plus splat" do
         _("def foo bar=1, *baz; end")
           .must_be_parsed_as s(:defn,

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -45,7 +45,7 @@ def foo
   end
 end
 
-# Pattern matching with types
+# Pattern matching with rightward assignment
 def foo
   case bar
     in [Hash => baz, String => quz]

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -45,6 +45,13 @@ def foo
   end
 end
 
+def foo
+  case bar
+    in [^baz]
+    qux = baz
+  end
+end
+
 # Pattern matching with rightward assignment
 def foo
   case bar

--- a/test/samples/ruby_31.rb
+++ b/test/samples/ruby_31.rb
@@ -15,3 +15,11 @@ end
 def foo(&)
   bar
 end
+
+# Pattern matching changes
+def foo
+  case bar
+    in [^(baz)]
+    qux = baz
+  end
+end

--- a/test/samples/ruby_31.rb
+++ b/test/samples/ruby_31.rb
@@ -5,3 +5,8 @@ def foo # Avoid comment attaching to next method
 end
 
 def foo = bar 42
+
+# Hash shorthand
+def foo(bar)
+  { bar: }
+end

--- a/test/samples/ruby_31.rb
+++ b/test/samples/ruby_31.rb
@@ -11,6 +11,7 @@ def foo(bar)
   { bar: }
 end
 
+# Bare block parameters
 def foo(&)
   bar
 end

--- a/test/samples/ruby_31.rb
+++ b/test/samples/ruby_31.rb
@@ -10,3 +10,7 @@ def foo = bar 42
 def foo(bar)
   { bar: }
 end
+
+def foo(&)
+  bar
+end

--- a/test/samples/ruby_31.rb
+++ b/test/samples/ruby_31.rb
@@ -23,3 +23,10 @@ def foo
     qux = baz
   end
 end
+
+def foo
+  case bar
+    in [^@a, ^$b, ^@@c]
+    qux = quuz(@a, @b, @@c)
+  end
+end


### PR DESCRIPTION
This adds support for the new Ruby 3.1 syntax features supported by RubyParser 3.19.0

- Add passing tests for shorthand hash syntax
- Add passing tests for bare block parameters
- Improve sample comments
- Check comment stack validity when processing comments
- Handle caret + parentheses in pattern matching
- Add passing tests for pattern matching with non-local variables
