### PR TITLE
Bump ruby_parser compatibility to 3.19.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Parse with Ripper, produce sexps that are compatible with RubyParser.
 * Drop-in replacement for RubyParser
 * Should handle 1.9 and later syntax gracefully
 * Requires Ruby 2.6 or higher
-* Compatible with RubyParser 3.18.0
+* Compatible with RubyParser 3.19.1
 
 ## Known incompatibilities
 

--- a/ripper_ruby_parser.gemspec
+++ b/ripper_ruby_parser.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-minitest", "~> 0.18.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.1"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"
-  spec.add_development_dependency "ruby_parser", "~> 3.19"
+  spec.add_development_dependency "ruby_parser", ["~> 3.19", ">= 3.19.1"]
   # Ensure sexp_processor's test cases match version 3.18.0 of ruby_parser.
   spec.add_development_dependency "sexp_processor", "~> 4.16"
   spec.add_development_dependency "simplecov", "~> 0.21.0"

--- a/test/samples/ruby_30.rb
+++ b/test/samples/ruby_30.rb
@@ -12,9 +12,6 @@ def foo(bar, ...)
 end
 
 # Endless methods
-def foo # FIXME: Avoid comment attaching to next method
-end
-
 def foo(bar) = baz(bar)
 def foo(bar) = baz(bar) rescue qux
 def baz = qux


### PR DESCRIPTION
- 3.19 supports some newer Ruby syntax
- 3.19.1 fixes comments for endless methods
