### PR TITLE
Handle method names that are keywords in method definitions

### DIFF
--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -348,7 +348,7 @@ module RipperRubyParser
     end
 
     def commentize(name, exp)
-      (_, kw, loc), comment = @comment_stack.pop
+      (_, kw, loc), comment = @comment_stack.pop while kw != name
 
       @comment = ""
       exp.push loc

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -93,12 +93,14 @@ module RipperRubyParser
       commentize("class", super)
     end
 
-    def on_def(*args)
-      commentize("def", super)
+    def on_def(name, *args)
+      (_, _, loc) = name
+      commentize("def", super, loc)
     end
 
-    def on_defs(*args)
-      commentize("def", super)
+    def on_defs(receiver, period, name, *rest)
+      (_, _, loc) = name
+      commentize("def", super, loc)
     end
 
     def on_args_new
@@ -347,8 +349,14 @@ module RipperRubyParser
       raise SyntaxError, message
     end
 
-    def commentize(name, exp)
-      (_, kw, loc), comment = @comment_stack.pop while kw != name
+    def commentize(name, exp, target_loc = nil)
+      if target_loc
+        (_, kw, loc), comment = @comment_stack.pop until (loc <=> target_loc) == -1
+      else
+        (_, kw, loc), comment = @comment_stack.pop
+      end
+
+      warn "Comment stack mismatch: expected #{kw} to equal #{name}" unless kw == name
 
       @comment = ""
       exp.push loc

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -349,9 +349,6 @@ module RipperRubyParser
 
     def commentize(name, exp)
       (_, kw, loc), comment = @comment_stack.pop
-      if kw != name
-        raise "Comment subject mismatch: expected #{name.inspect}, found #{kw.inspect}"
-      end
 
       @comment = ""
       exp.push loc

--- a/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
+++ b/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
@@ -18,7 +18,7 @@ describe RipperRubyParser::CommentingRipperParser do
     #
     # See https://bugs.ruby-lang.org/issues/15670
     let(:dsym_string_type) do
-      if RUBY_VERSION >= "2.6.3"
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.3")
         :string_content
       else
         :xstring
@@ -191,7 +191,7 @@ describe RipperRubyParser::CommentingRipperParser do
       _(result).must_equal s(:program,
                              s(:stmts,
                                s(:string_literal,
-                                 s(:string_content,
+                                 s(dsym_string_type,
                                    s(:@tstring_content, "", s(2, 2), "<<~FOO"),
                                    s(:string_embexpr,
                                      s(:stmts,

--- a/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
+++ b/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
@@ -132,7 +132,7 @@ describe RipperRubyParser::CommentingRipperParser do
                                    empty_params_list,
                                    s(:bodystmt,
                                      s(:stmts, s(:void_stmt, s(1, 14))), nil, nil, nil),
-                                   s(1, 4)))))
+                                   s(1, 0)))))
     end
 
     it "is not confused by a dynamic symbol" do

--- a/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
+++ b/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
@@ -122,6 +122,19 @@ describe RipperRubyParser::CommentingRipperParser do
                                    s(1, 8)))))
     end
 
+    it "does not crash on a method named 'class'" do
+      result = parse_with_builder "def class; end"
+      _(result).must_equal s(:program,
+                             s(:stmts,
+                               s(:comment, "",
+                                 s(:def,
+                                   s(:@kw, "class", s(1, 4)),
+                                   empty_params_list,
+                                   s(:bodystmt,
+                                     s(:stmts, s(:void_stmt, s(1, 14))), nil, nil, nil),
+                                   s(1, 4)))))
+    end
+
     it "is not confused by a dynamic symbol" do
       result = parse_with_builder ":'foo'; def bar; end"
       _(result).must_equal s(:program,

--- a/test/ripper_ruby_parser/parser_test.rb
+++ b/test/ripper_ruby_parser/parser_test.rb
@@ -366,6 +366,35 @@ describe RipperRubyParser::Parser do
         _(result.comments).must_equal "# Foo\n"
       end
 
+      it "assigns comments correctly when method name is def" do
+        result = parser.parse <<~RUBY
+          # Bar
+          def def
+          end
+        RUBY
+        _(result).must_equal s(:defn, :def, s(:args), s(:nil))
+        _(result.comments).must_equal "# Bar\n"
+      end
+
+      it "assigns comments correctly when method name is class" do
+        result = parser.parse <<~RUBY
+          # Foo
+          class Foo
+            # Bar
+            self.class
+
+            # Baz
+            def class
+            end
+          end
+        RUBY
+        _(result).must_equal s(:class, :Foo, nil,
+                               s(:call, s(:self), :class),
+                               s(:defn, :class, s(:args), s(:nil)))
+        _(result.comments).must_equal "# Foo\n"
+        _(result[4].comments).must_equal "# Bar\n# Baz\n"
+      end
+
       # TODO: Prefer assigning comment to the BEGIN instead
       it "assigns comments on BEGIN blocks to the following item" do
         result = parser.parse "# Bar\nBEGIN { }\n# Foo\ndef foo; end"

--- a/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
@@ -242,6 +242,11 @@ describe RipperRubyParser::Parser do
                                s(:nil).line(2)).line(1),
                              with_line_numbers: true
       end
+
+      it "handles a method named 'class'" do
+        _("def class; end")
+          .must_be_parsed_as s(:defn, :class, s(:args), s(:nil))
+      end
     end
 
     describe "for endless instance method definitions" do

--- a/test/samples/misc.rb
+++ b/test/samples/misc.rb
@@ -303,6 +303,19 @@ if defined? foo
   bar
 end
 
+# Methods with names that are also keywords
+class Bar
+  # Command A
+  def begin
+    foo.end.begin
+  end
+
+  # Command B
+  def class
+    "Woof!"
+  end
+end
+
 # Endless ranges
 1..
 

--- a/test/samples/misc.rb
+++ b/test/samples/misc.rb
@@ -314,6 +314,12 @@ class Bar
   def class
     "Woof!"
   end
+
+  # Foo
+  def def
+    # Bar
+    self.def.def;
+  end
 end
 
 # Endless ranges

--- a/test/samples/ruby_31.rb
+++ b/test/samples/ruby_31.rb
@@ -1,9 +1,6 @@
 # Samples that need Ruby 3.0 or higher
 
 # Endless methods with bodies with arguments without parentheses
-def foo # Avoid comment attaching to next method
-end
-
 def foo = bar 42
 
 # Hash shorthand


### PR DESCRIPTION
- Allow for keywords used as method names
- Remove old hack in Ruby 3.1 sample
- Add sample of the interaction of keyword-named methods and comments
- Pop comment stack until keywords match up
- Add an even worse example with keyword-named methods
- Pop comment stack based on target location for def and defs
