### PR TITLE
Update to match output of ruby_parser version 3.19.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Parse with Ripper, produce sexps that are compatible with RubyParser.
 * Drop-in replacement for RubyParser
 * Should handle 1.9 and later syntax gracefully
 * Requires Ruby 2.6 or higher
-* Compatible with RubyParser 3.19.1
+* Compatible with RubyParser 3.19.2
 
 ## Known incompatibilities
 

--- a/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/conditionals.rb
@@ -74,6 +74,7 @@ module RipperRubyParser
                       falsepart.sexp_body
                     end
         pattern = process(pattern)
+        adjust_rightward_assignment_pattern(pattern)
 
         s(:case_body,
           s(:in, pattern, process(truepart)),
@@ -135,6 +136,15 @@ module RipperRubyParser
           @local_variables << pattern[1]
         end
         pattern
+      end
+
+      def adjust_rightward_assignment_pattern(exp)
+        case exp.sexp_type
+        when :lvar
+          exp.sexp_type = :lasgn
+        when :lasgn
+          adjust_rightward_assignment_pattern(exp.sexp_body.last)
+        end
       end
 
       def construct_conditional(cond, truepart, falsepart)

--- a/lib/ripper_ruby_parser/sexp_handlers/string_literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/string_literals.rb
@@ -238,10 +238,8 @@ module RipperRubyParser
 
       def handle_string_unescaping(content, delim)
         case delim
-        when INTERPOLATING_HEREDOC, *INTERPOLATING_STRINGS
+        when INTERPOLATING_HEREDOC, INTERPOLATING_DSYM, *INTERPOLATING_STRINGS
           unescape(content)
-        when INTERPOLATING_DSYM
-          unescape_dsym(content)
         when INTERPOLATING_WORD_LIST
           fix_encoding unescape_wordlist_word(content)
         when *NON_INTERPOLATING_STRINGS

--- a/lib/ripper_ruby_parser/unescape.rb
+++ b/lib/ripper_ruby_parser/unescape.rb
@@ -92,25 +92,6 @@ module RipperRubyParser
       end
     end
 
-    def unescape_dsym(string)
-      string = string.dup if string.frozen?
-      old_encoding = string.encoding
-      restore_encoding = true
-      string.force_encoding("ASCII-8BIT")
-      unescaped = string.gsub(ESCAPE_SEQUENCE_REGEXP) do
-        bare = Regexp.last_match[1]
-        if bare == "\n"
-          ""
-        else
-          replacement = unescaped_value(bare)
-          replacement.force_encoding old_encoding
-          restore_encoding = false unless replacement.valid_encoding?
-          replacement.force_encoding("ASCII-8BIT")
-        end
-      end
-      restore_encoding ? unescaped.force_encoding(old_encoding) : unescaped
-    end
-
     def fix_encoding(string)
       unless string.encoding == Encoding::UTF_8
         dup = string.dup.force_encoding Encoding::UTF_8

--- a/ripper_ruby_parser.gemspec
+++ b/ripper_ruby_parser.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "sexp_processor", "~> 4.10"
 
   spec.add_development_dependency "minitest", "~> 5.6"
-  spec.add_development_dependency "minitest-focus", ["~> 1.3", ">= 1.3.1"]
+  spec.add_development_dependency "minitest-focus", "~> 1.3", ">= 1.3.1"
   spec.add_development_dependency "pry", "~> 0.14.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-minitest", "~> 0.24.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.1"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"
-  spec.add_development_dependency "ruby_parser", ["~> 3.19", ">= 3.19.1"]
+  spec.add_development_dependency "ruby_parser", "~> 3.19", ">= 3.19.2"
   # Ensure sexp_processor's test cases match version 3.18.0 of ruby_parser.
   spec.add_development_dependency "sexp_processor", "~> 4.16"
   spec.add_development_dependency "simplecov", "~> 0.21.0"

--- a/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
@@ -651,7 +651,7 @@ describe RipperRubyParser::Parser do
 
       it "works for the simple case" do
         _("42 => foo")
-          .must_be_parsed_as s(:case, s(:lit, 42), s(:in, s(:lvar, :foo), nil), nil)
+          .must_be_parsed_as s(:case, s(:lit, 42), s(:in, s(:lasgn, :foo), nil), nil)
       end
     end
   end

--- a/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
@@ -543,7 +543,7 @@ describe RipperRubyParser::Parser do
           .must_be_parsed_as s(:case,
                                s(:call, nil, :foo),
                                s(:in,
-                                 s(:lvar, :bar),
+                                 s(:lasgn, :bar),
                                  s(:call, nil, :qux,
                                    s(:lvar, :bar))), nil)
       end
@@ -556,7 +556,7 @@ describe RipperRubyParser::Parser do
                                  s(:array_pat, nil, s(:str, "a")),
                                  s(:call, nil, :bar)),
                                s(:in,
-                                 s(:lvar, :qux),
+                                 s(:lasgn, :qux),
                                  s(:call, nil, :quuz, s(:lvar, :qux))), nil)
       end
 
@@ -645,7 +645,7 @@ describe RipperRubyParser::Parser do
         _("1 in foo").must_be_parsed_as s(:case,
                                           s(:lit, 1),
                                           s(:in,
-                                            s(:lvar, :foo), nil), nil)
+                                            s(:lasgn, :foo), nil), nil)
       end
 
       it "works for secondary assignment of matched expression" do
@@ -653,7 +653,16 @@ describe RipperRubyParser::Parser do
                                                  s(:lit, 1),
                                                  s(:in,
                                                    s(:lasgn, :bar,
-                                                     s(:lvar, :foo)), nil), nil)
+                                                     s(:lasgn, :foo)), nil), nil)
+      end
+
+      it "works for tertiary assignment of matched expression" do
+        _("1 in foo => bar => baz").must_be_parsed_as s(:case,
+                                                        s(:lit, 1),
+                                                        s(:in,
+                                                          s(:lasgn, :baz,
+                                                            s(:lasgn, :bar,
+                                                              s(:lasgn, :foo))), nil), nil)
       end
     end
   end

--- a/test/ripper_ruby_parser/sexp_handlers/string_literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/string_literals_test.rb
@@ -1061,9 +1061,8 @@ describe RipperRubyParser::Parser do
       end
 
       it "works for dsyms containing raw byte escape sequences" do
-        expected_symbol = (+"Variet\303\240").force_encoding("ascii-8bit").to_sym
         _(":\"Variet\\303\\240\"")
-          .must_be_parsed_as s(:lit, expected_symbol)
+          .must_be_parsed_as s(:lit, :Varietà)
       end
 
       it "works for dsyms containing non-ascii characters" do


### PR DESCRIPTION
- Bump minumum require ruby_parser version to 3.19.2
- Update handling of symbols with raw byte escape sequences
- Update handling of rightward assignment
- Update README with new compatibility version
