### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
   Exclude:
     - 'test/samples/*'
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 # Make BeginEndAlignment behavior match EndAlignment
 Layout/BeginEndAlignment:

--- a/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/blocks.rb
@@ -223,11 +223,7 @@ module RipperRubyParser
       def make_iter(call, args, stmt)
         args[-1] = nil if args && args.last == s(:excessed_comma)
 
-        args ||= if RUBY_VERSION >= "2.7.0"
-                   count_numbered_lvars(stmt)
-                 else
-                   0
-                 end
+        args ||= count_numbered_lvars(stmt)
 
         if stmt.empty?
           s(:iter, call, args)

--- a/ripper_ruby_parser.gemspec
+++ b/ripper_ruby_parser.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "http://www.github.com/mvz/ripper_ruby_parser"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/ripper_ruby_parser"

--- a/test/end_to_end/samples_comparison_test.rb
+++ b/test/end_to_end/samples_comparison_test.rb
@@ -7,7 +7,6 @@ describe "Using RipperRubyParser and RubyParser" do
   make_my_diffs_pretty!
 
   Dir.glob(File.expand_path("../samples/*.rb", File.dirname(__FILE__))).each do |file|
-    next if RUBY_VERSION < "2.7.0" && file.match?(/_27.rb\Z/)
     next if RUBY_VERSION < "3.0.0" && file.match?(/_30.rb\Z/)
     next if RUBY_VERSION < "3.1.0" && file.match?(/_31.rb\Z/)
 

--- a/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
+++ b/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
@@ -13,18 +13,6 @@ describe RipperRubyParser::CommentingRipperParser do
   end
 
   describe "handling comments" do
-    # Handle different results for dynamic symbol strings. This was changed in
-    # Ruby 2.7.0, and backported to 2.6.3
-    #
-    # See https://bugs.ruby-lang.org/issues/15670
-    let(:dsym_string_type) do
-      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.3")
-        :string_content
-      else
-        :xstring
-      end
-    end
-
     it "produces a comment node surrounding a commented def" do
       result = parse_with_builder "# Foo\ndef foo; end"
       _(result).must_equal s(:program,
@@ -140,7 +128,7 @@ describe RipperRubyParser::CommentingRipperParser do
       _(result).must_equal s(:program,
                              s(:stmts,
                                s(:dyna_symbol,
-                                 s(dsym_string_type,
+                                 s(:string_content,
                                    s(:@tstring_content, "foo", s(1, 2), ":'"))),
                                s(:comment,
                                  "",
@@ -157,7 +145,7 @@ describe RipperRubyParser::CommentingRipperParser do
       _(result).must_equal s(:program,
                              s(:stmts,
                                s(:dyna_symbol,
-                                 s(dsym_string_type,
+                                 s(:string_content,
                                    s(:@tstring_content, "foo", s(1, 2), ':"'),
                                    s(:string_embexpr,
                                      s(:stmts,
@@ -191,7 +179,7 @@ describe RipperRubyParser::CommentingRipperParser do
       _(result).must_equal s(:program,
                              s(:stmts,
                                s(:string_literal,
-                                 s(dsym_string_type,
+                                 s(:string_content,
                                    s(:@tstring_content, "", s(2, 2), "<<~FOO"),
                                    s(:string_embexpr,
                                      s(:stmts,

--- a/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
@@ -247,20 +247,12 @@ describe RipperRubyParser::Parser do
       end
 
       it "works with a rescue modifier" do
-        expected = if RUBY_VERSION < "2.7.0"
-                     s(:rescue,
-                       s(:masgn,
-                         s(:array, s(:lasgn, :foo), s(:lasgn, :bar)),
-                         s(:to_ary, s(:call, nil, :baz))),
-                       s(:resbody, s(:array), s(:call, nil, :qux)))
-                   else
-                     s(:masgn,
-                       s(:array, s(:lasgn, :foo), s(:lasgn, :bar)),
-                       s(:to_ary,
-                         s(:rescue,
-                           s(:call, nil, :baz),
-                           s(:resbody, s(:array), s(:call, nil, :qux)))))
-                   end
+        expected = s(:masgn,
+                     s(:array, s(:lasgn, :foo), s(:lasgn, :bar)),
+                     s(:to_ary,
+                       s(:rescue,
+                         s(:call, nil, :baz),
+                         s(:resbody, s(:array), s(:call, nil, :qux)))))
 
         _("foo, bar = baz rescue qux")
           .must_be_parsed_as expected

--- a/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/blocks_test.rb
@@ -221,28 +221,12 @@ describe RipperRubyParser::Parser do
       end
 
       it "works with numbered parameters" do
-        if RUBY_VERSION < "2.7.0"
-          skip "This Ruby version does not support numbered parameters"
-        end
         _("foo do _1.bar(_2); end")
           .must_be_parsed_as \
             s(:iter,
               s(:call, nil, :foo),
               2,
               s(:call, s(:lvar, :_1), :bar, s(:lvar, :_2)))
-      end
-
-      it "parses code that looks like numbered parameters correctly on older rubies" do
-        if RUBY_VERSION >= "2.7.0"
-          skip "This Ruby version interprets this code as numbered parameters"
-        end
-        _("_1 = 1; foo { bar _1, _2 }")
-          .must_be_parsed_as \
-            s(:block,
-              s(:lasgn, :_1, s(:lit, 1)),
-              s(:iter,
-                s(:call, nil, :foo), 0,
-                s(:call, nil, :bar, s(:lvar, :_1), s(:call, nil, :_2))))
       end
     end
 

--- a/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
@@ -534,10 +534,6 @@ describe RipperRubyParser::Parser do
     end
 
     describe "for a case block with in clauses" do
-      before do
-        skip "This Ruby version does not support pattern matching" if RUBY_VERSION < "2.7.0"
-      end
-
       it "works with a single in clause" do
         _("case foo; in bar; qux bar; end")
           .must_be_parsed_as s(:case,
@@ -637,10 +633,6 @@ describe RipperRubyParser::Parser do
     end
 
     describe "for one-line pattern matching" do
-      before do
-        skip "This Ruby version does not support pattern matching" if RUBY_VERSION < "2.7.0"
-      end
-
       it "works for the simple case" do
         _("1 in foo").must_be_parsed_as s(:case,
                                           s(:lit, 1),

--- a/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
@@ -225,9 +225,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "works with argument forwarding" do
-        if RUBY_VERSION < "2.7.0"
-          skip "This Ruby version does not support argument forwarding"
-        end
         _("def foo(...); bar(...); end")
           .must_be_parsed_as s(:defn, :foo,
                                s(:args, s(:forward_args)),

--- a/test/ripper_ruby_parser/sexp_handlers/operators_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/operators_test.rb
@@ -241,7 +241,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "handles beginless range literals" do
-        skip "This Ruby version does not support beginless ranges" if RUBY_VERSION < "2.7.0"
         _("..1")
           .must_be_parsed_as s(:dot2, nil, s(:lit, 1))
       end
@@ -306,7 +305,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "handles beginless range literals" do
-        skip "This Ruby version does not support beginless ranges" if RUBY_VERSION < "2.7.0"
         _("...1")
           .must_be_parsed_as s(:dot3, nil, s(:lit, 1))
       end


### PR DESCRIPTION
- Require Ruby 2.7 in the gemspec
- Stop testing with 2.6
- Update target Ruby version in RuboCop configuration
- Remove now-obsolete version checks
