### PR TITLE
Add version check for argument forwarding tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,8 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7.0", "2.7.2", "2.7.3", "2.7", "3.0", "3.1", "3.2"]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,10 @@ Gemspec/DevelopmentDependencies:
 Layout/BeginEndAlignment:
   EnforcedStyleAlignWith: begin
 
+# Spaces in strings with line continuations go at the beginning of the line.
+Layout/LineContinuationLeadingSpace:
+  EnforcedStyle: leading
+
 # Be lenient with line length
 Layout/LineLength:
   Max: 92

--- a/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
@@ -231,6 +231,46 @@ describe RipperRubyParser::Parser do
                                s(:call, nil, :bar, s(:forward_args)))
       end
 
+      it "works with argument forwarding with leading call arguments" do
+        # Implemented in 3.0 and backported to 2.7.3.
+        # See https://bugs.ruby-lang.org/issues/16378
+        if RUBY_VERSION < "2.7.3"
+          skip "This Ruby version does not support this style of argument forwarding"
+        end
+        _("def foo(...); bar(baz, ...); end")
+          .must_be_parsed_as s(:defn, :foo,
+                               s(:args, s(:forward_args)),
+                               s(:call, nil, :bar,
+                                 s(:call, nil, :baz), s(:forward_args)))
+      end
+
+      it "works with argument forwarding with leading method arguments" do
+        # Implemented in 3.0 and backported to 2.7.3.
+        # See https://bugs.ruby-lang.org/issues/16378
+        if RUBY_VERSION < "2.7.3"
+          skip "This Ruby version does not support this style of argument forwarding"
+        end
+        _("def foo(bar, ...); baz(...); end")
+          .must_be_parsed_as s(:defn, :foo,
+                               s(:args, :bar, s(:forward_args)),
+                               s(:call, nil, :baz,
+                                 s(:forward_args)))
+      end
+
+      it "works for multi-statement method body with argument forwarding" \
+         " with leading method arguments" do
+        # Implemented in 3.0 and backported to 2.7.3.
+        # See https://bugs.ruby-lang.org/issues/16378
+        if RUBY_VERSION < "2.7.3"
+          skip "This Ruby version does not support this style of argument forwarding"
+        end
+        _("def foo(bar, ...); baz bar; qux(...); end")
+          .must_be_parsed_as s(:defn, :foo,
+                               s(:args, :bar, s(:forward_args)),
+                               s(:call, nil, :baz, s(:lvar, :bar)),
+                               s(:call, nil, :qux, s(:forward_args)))
+      end
+
       it "works with an anonymous splat argument" do
         _("def foo(*); end")
           .must_be_parsed_as s(:defn, :foo,

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -2,12 +2,12 @@
 
 # Beginless ranges
 ..1
+foo = 2
 ..foo
 
 # Argument forwarding
 def foo(...)
   bar(...)
-  bar(qux, ...)
 end
 
 # Pattern matching (experimental)

--- a/test/samples/ruby_30.rb
+++ b/test/samples/ruby_30.rb
@@ -11,6 +11,12 @@ def foo(bar, ...)
   qux(...)
 end
 
+# Argument forwarding with leading argument in call
+def foo(...)
+  bar(...)
+  bar(qux, ...)
+end
+
 # Endless methods
 def foo(bar) = baz(bar)
 def foo(bar) = baz(bar) rescue qux


### PR DESCRIPTION
The option to include leading arguments in method definitions and method calls that use argument forwarding was introduced in Ruby 3.0 and backported to Ruby 2.7.3.
