### PR TITLE
Support Ruby 3.0 through 3.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.7.0", "2.7.2", "2.7.3", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0.0", "3.0", "3.1", "3.2", "3.3"]
       fail-fast: false
 
     steps:
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop -P

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
   Exclude:
     - 'test/samples/*'
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -330,7 +330,8 @@ module RipperRubyParser
     end
 
     def on_parse_error(message)
-      raise SyntaxError, message
+      super
+      raise SyntaxError, message if message.start_with?("syntax error,")
     end
 
     def on_class_name_error(message, *)

--- a/lib/ripper_ruby_parser/sexp_handlers/string_literals.rb
+++ b/lib/ripper_ruby_parser/sexp_handlers/string_literals.rb
@@ -227,13 +227,13 @@ module RipperRubyParser
         end
       end
 
-      INTERPOLATING_HEREDOC = /^<<[-~]?[^-~']/.freeze
-      NON_INTERPOLATING_HEREDOC = /^<<[-~]?'/.freeze
+      INTERPOLATING_HEREDOC = /^<<[-~]?[^-~']/
+      NON_INTERPOLATING_HEREDOC = /^<<[-~]?'/
       INTERPOLATING_STRINGS = ['"', "`", /^%Q.$/, /^%.$/].freeze
       INTERPOLATING_DSYM = ':"'
       NON_INTERPOLATING_STRINGS = ["'", ":'", /^%q.$/].freeze
-      INTERPOLATING_WORD_LIST = /^%[WI].$/.freeze
-      NON_INTERPOLATING_WORD_LIST = /^%[wi].$/.freeze
+      INTERPOLATING_WORD_LIST = /^%[WI].$/
+      NON_INTERPOLATING_WORD_LIST = /^%[wi].$/
       REGEXP_LITERALS = ["/", /^%r.$/].freeze
 
       def handle_string_unescaping(content, delim)

--- a/lib/ripper_ruby_parser/unescape.rb
+++ b/lib/ripper_ruby_parser/unescape.rb
@@ -20,7 +20,7 @@ module RipperRubyParser
         M-.                 | # meta
         \n                  | # line break
         .                     # other single character
-      )/x.freeze
+      )/x
 
     SINGLE_LETTER_ESCAPES = {
       "a" => "\a",

--- a/ripper_ruby_parser.gemspec
+++ b/ripper_ruby_parser.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "http://www.github.com/mvz/ripper_ruby_parser"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/ripper_ruby_parser"

--- a/test/end_to_end/samples_comparison_test.rb
+++ b/test/end_to_end/samples_comparison_test.rb
@@ -7,7 +7,6 @@ describe "Using RipperRubyParser and RubyParser" do
   make_my_diffs_pretty!
 
   Dir.glob(File.expand_path("../samples/*.rb", File.dirname(__FILE__))).each do |file|
-    next if RUBY_VERSION < "3.0.0" && file.match?(/_30.rb\Z/)
     next if RUBY_VERSION < "3.1.0" && file.match?(/_31.rb\Z/)
     next if RUBY_VERSION < "3.2.0" && file.match?(/_32.rb\Z/)
 

--- a/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
+++ b/test/ripper_ruby_parser/commenting_ripper_parser_test.rb
@@ -188,7 +188,7 @@ describe RipperRubyParser::CommentingRipperParser do
     end
   end
 
-  describe "handling syntax errors" do
+  describe "handling errors" do
     it "raises an error for an incomplete source" do
       _(proc { parse_with_builder "def foo" }).must_raise RipperRubyParser::SyntaxError
     end
@@ -217,6 +217,15 @@ describe RipperRubyParser::CommentingRipperParser do
     it "raises an error using an invalid parameter name" do
       _(proc { parse_with_builder "def foo(BAR); end" })
         .must_raise RipperRubyParser::SyntaxError
+    end
+
+    it "records non-fatal errors" do
+      skip "No error is detected in this Ruby version" if RUBY_VERSION < "3.3.0"
+
+      builder = RipperRubyParser::CommentingRipperParser.new "yield"
+      result = builder.parse
+      _(result).must_equal s(:program, s(:stmts, s(:yield0)))
+      _(builder.error).must_equal "Invalid yield"
     end
   end
 end

--- a/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/assignment_test.rb
@@ -635,12 +635,6 @@ describe RipperRubyParser::Parser do
     end
 
     describe "for rightward assignment" do
-      before do
-        if RUBY_VERSION < "3.0.0"
-          skip "This Ruby version does not support rightward assignment"
-        end
-      end
-
       it "works for the simple case" do
         _("42 => foo")
           .must_be_parsed_as s(:case, s(:lit, 42), s(:in, s(:lasgn, :foo), nil), nil)

--- a/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
@@ -640,7 +640,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "works with the find pattern" do
-        skip "This Ruby version does not support the find pattern" if RUBY_VERSION < "3.0.0"
         _("case foo; in [*, :baz, qux, *]; end")
           .must_be_parsed_as s(:case,
                                s(:call, nil, :foo),
@@ -650,7 +649,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "works with the find pattern with splat variables" do
-        skip "This Ruby version does not support the find pattern" if RUBY_VERSION < "3.0.0"
         _("case foo; in [*bar, :baz, qux, *quuz]; end")
           .must_be_parsed_as s(:case,
                                s(:call, nil, :foo),
@@ -661,7 +659,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "works with the find pattern with constant wrapper with square brackets" do
-        skip "This Ruby version does not support the find pattern" if RUBY_VERSION < "3.0.0"
         _("case foo; in Array[*bar, :baz, qux, *quuz]; end")
           .must_be_parsed_as s(:case,
                                s(:call, nil, :foo),
@@ -672,7 +669,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "works with the find pattern with constant wrapper with parentheses" do
-        skip "This Ruby version does not support the find pattern" if RUBY_VERSION < "3.0.0"
         _("case foo; in Array(*bar, :baz, qux, *quuz); end")
           .must_be_parsed_as s(:case,
                                s(:call, nil, :foo),

--- a/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
@@ -232,11 +232,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "works with argument forwarding with leading call arguments" do
-        # Implemented in 3.0 and backported to 2.7.3.
-        # See https://bugs.ruby-lang.org/issues/16378
-        if RUBY_VERSION < "2.7.3"
-          skip "This Ruby version does not support this style of argument forwarding"
-        end
         _("def foo(...); bar(baz, ...); end")
           .must_be_parsed_as s(:defn, :foo,
                                s(:args, s(:forward_args)),
@@ -245,11 +240,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "works with argument forwarding with leading method arguments" do
-        # Implemented in 3.0 and backported to 2.7.3.
-        # See https://bugs.ruby-lang.org/issues/16378
-        if RUBY_VERSION < "2.7.3"
-          skip "This Ruby version does not support this style of argument forwarding"
-        end
         _("def foo(bar, ...); baz(...); end")
           .must_be_parsed_as s(:defn, :foo,
                                s(:args, :bar, s(:forward_args)),
@@ -259,11 +249,6 @@ describe RipperRubyParser::Parser do
 
       it "works for multi-statement method body with argument forwarding" \
          " with leading method arguments" do
-        # Implemented in 3.0 and backported to 2.7.3.
-        # See https://bugs.ruby-lang.org/issues/16378
-        if RUBY_VERSION < "2.7.3"
-          skip "This Ruby version does not support this style of argument forwarding"
-        end
         _("def foo(bar, ...); baz bar; qux(...); end")
           .must_be_parsed_as s(:defn, :foo,
                                s(:args, :bar, s(:forward_args)),
@@ -301,10 +286,6 @@ describe RipperRubyParser::Parser do
     end
 
     describe "for endless instance method definitions" do
-      before do
-        skip "This Ruby version does not support endless methods" if RUBY_VERSION < "3.0.0"
-      end
-
       it "works for a method with simple arguments" do
         _("def foo(bar) = baz(bar)")
           .must_be_parsed_as s(:defn,
@@ -374,10 +355,6 @@ describe RipperRubyParser::Parser do
     end
 
     describe "for endless singleton method definitions" do
-      before do
-        skip "This Ruby version does not support endless methods" if RUBY_VERSION < "3.0.0"
-      end
-
       it "works for a method with simple arguments" do
         _("def self.foo(bar) = baz(bar)")
           .must_be_parsed_as s(:defs,

--- a/test/samples/ruby_30.rb
+++ b/test/samples/ruby_30.rb
@@ -29,4 +29,8 @@ def foo(bar) = baz(bar)
 def foo(bar) = baz(bar) rescue qux
 def baz = qux
 
-def bar.baz = qux
+def zyxxy.baz = qux
+
+# TODO: The following code is parsed differently in Ruby 3.3 because 'bar' is
+# considered in lvar there:
+# def bar.baz = qux


### PR DESCRIPTION
- Drop support for Ruby 2.7
- Build with Rubies 3.0 through 3.3 in CI
- Remove obsolete RUBY_VERSION checks
- Autocorrect Style/RedundantFreeze
- Only raise SyntaxError if Ripper error is really a syntax error
- Work around a subtle compatibility issue in end-to-end tests 
