### PR TITLE
Improve consistency checks in comment processing

### DIFF
--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -70,15 +70,17 @@ module RipperRubyParser
     end
 
     def on_kw(tok)
-      result = super
-      case tok
-      when "class", "def", "module", "BEGIN", "begin", "END"
-        unless @in_symbol
+      super.tap do |result|
+        next if @in_symbol
+
+        case tok
+        when "class", "def", "module", "BEGIN", "begin", "END"
           @comment_stack.push [result, @comment]
           @comment = ""
+        when "end"
+          @comment = "" if @comment_stack.any?
         end
       end
-      result
     end
 
     def on_module(*args)
@@ -351,6 +353,8 @@ module RipperRubyParser
     end
 
     def commentize(name, exp, target_loc = nil)
+      raise "Non-empty comment in progress: #{@comment}" unless @comment.empty?
+
       if target_loc
         (_, kw, loc), comment = @comment_stack.pop until (loc <=> target_loc) == -1
       else

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -357,7 +357,7 @@ module RipperRubyParser
         (_, kw, loc), comment = @comment_stack.pop
       end
 
-      warn "Comment stack mismatch: expected #{kw} to equal #{name}" unless kw == name
+      raise "Comment stack mismatch: expected #{kw} to equal #{name}" unless kw == name
 
       @comment = ""
       exp.push loc


### PR DESCRIPTION
This is a small internal improvement in preparation for the update to compatibility with `ruby_parser` 3.21.

- Make stack mismatch in comment processing an error
- Require that no comments are in progress when applying comments
