### PR TITLE
Support Ruby 3.1 through 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0.0", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1.0", "3.1", "3.2", "3.3", "3.4"]
       fail-fast: false
 
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
   Exclude:
     - 'test/samples/*'
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Parse with Ripper, produce sexps that are compatible with RubyParser.
 
 * Drop-in replacement for RubyParser
 * Should handle 1.9 and later syntax gracefully
-* Requires Ruby 3.0 or higher
+* Requires Ruby 3.1 or higher
 * Compatible with RubyParser 3.21.0
 
 ## Known incompatibilities
@@ -22,6 +22,8 @@ RipperRubyParser has a few incompatibilities with RubyParser.
 * RipperRubyParser does not always match RubyParser's line numbering
 * RipperRubyParser dedents auto-dedenting heredocs
 * RipperRubyParser does not include postfix comments
+* With Ruby 3.4, RipperRubyParser parses variables assigned by regular
+  expressions as local variables
 
 ## Install
 

--- a/ripper_ruby_parser.gemspec
+++ b/ripper_ruby_parser.gemspec
@@ -14,8 +14,9 @@ Gem::Specification.new do |spec|
     drop-in replacement for RubyParser.
   DESC
   spec.homepage = "http://www.github.com/mvz/ripper_ruby_parser"
+
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/ripper_ruby_parser"

--- a/test/end_to_end/samples_comparison_test.rb
+++ b/test/end_to_end/samples_comparison_test.rb
@@ -7,7 +7,6 @@ describe "Using RipperRubyParser and RubyParser" do
   make_my_diffs_pretty!
 
   Dir.glob(File.expand_path("../samples/*.rb", File.dirname(__FILE__))).each do |file|
-    next if RUBY_VERSION < "3.1.0" && file.match?(/_31.rb\Z/)
     next if RUBY_VERSION < "3.2.0" && file.match?(/_32.rb\Z/)
 
     it "gives the same result for #{file}" do

--- a/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/conditionals_test.rb
@@ -619,7 +619,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "works with an in clause with caret and parentheses" do
-        skip "This Ruby version does not support caret + parens" if RUBY_VERSION < "3.1.0"
         _("case foo; in [^(baz)]; qux baz; end")
           .must_be_parsed_as s(:case,
                                s(:call, nil, :foo),
@@ -629,7 +628,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "works with an in clause with carets with instance, class and global variables" do
-        skip "This Ruby version does not support caret + parens" if RUBY_VERSION < "3.1.0"
         _("case foo; in [^@a, ^$b, ^@@c]; qux baz; end")
           .must_be_parsed_as s(:case,
                                s(:call, nil, :foo),

--- a/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/literals_test.rb
@@ -113,9 +113,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "works for shorthand hash syntax" do
-        if RUBY_VERSION < "3.1.0"
-          skip "This Ruby version does not support shorthand hash syntax"
-        end
         _("{ foo: }")
           .must_be_parsed_as s(:hash, s(:lit, :foo), nil)
       end

--- a/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/methods_test.rb
@@ -135,9 +135,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "works for a bare block parameter" do
-        if RUBY_VERSION < "3.1.0"
-          skip "This Ruby version does not support bare block parameters"
-        end
         _("def foo &; end")
           .must_be_parsed_as s(:defn,
                                :foo,
@@ -310,7 +307,6 @@ describe RipperRubyParser::Parser do
       end
 
       it "works when the body calls a method without parentheses" do
-        skip "This Ruby version does not support this syntax" if RUBY_VERSION < "3.1.0"
         _("def foo = bar 42")
           .must_be_parsed_as s(:defn, :foo, s(:args), s(:call, nil, :bar, s(:lit, 42)))
       end

--- a/test/ripper_ruby_parser/sexp_handlers/operators_test.rb
+++ b/test/ripper_ruby_parser/sexp_handlers/operators_test.rb
@@ -423,12 +423,20 @@ describe RipperRubyParser::Parser do
         end
 
         it "handles :=~ with variable-assigning regexp" do
-          _("/(?<foo>bar)/ =~ baz; foo")
-            .must_be_parsed_as s(:block,
-                                 s(:match2,
-                                   s(:lit, /(?<foo>bar)/),
-                                   s(:call, nil, :baz)),
-                                 s(:call, nil, :foo))
+          expected = if RUBY_VERSION < "3.4.0"
+                       s(:block,
+                         s(:match2,
+                           s(:lit, /(?<foo>bar)/),
+                           s(:call, nil, :baz)),
+                         s(:call, nil, :foo))
+                     else
+                       s(:block,
+                         s(:match2,
+                           s(:lit, /(?<foo>bar)/),
+                           s(:call, nil, :baz)),
+                         s(:lvar, :foo))
+                     end
+          _("/(?<foo>bar)/ =~ baz; foo").must_be_parsed_as expected
         end
 
         it "handles :=~ with statically interpolated variable-assigning regexp" do


### PR DESCRIPTION
This drops support for Ruby 3.0 which is EOL.
