### PR TITLE
Make ripper_ruby_parser compatible with ruby_parser 3.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Parse with Ripper, produce sexps that are compatible with RubyParser.
 * Drop-in replacement for RubyParser
 * Should handle 1.9 and later syntax gracefully
 * Requires Ruby 3.0 or higher
-* Compatible with RubyParser 3.20.2
+* Compatible with RubyParser 3.21.0
 
 ## Known incompatibilities
 

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -328,6 +328,11 @@ module RipperRubyParser
       super
     end
 
+    def on_string_content(*args)
+      @comment = ""
+      super
+    end
+
     def on_BEGIN(*args)
       commentize("BEGIN", super)
     end

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -323,6 +323,11 @@ module RipperRubyParser
       super
     end
 
+    def on_ident(*args)
+      @comment = ""
+      super
+    end
+
     def on_BEGIN(*args)
       commentize("BEGIN", super)
     end

--- a/lib/ripper_ruby_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_ruby_parser/commenting_ripper_parser.rb
@@ -323,6 +323,11 @@ module RipperRubyParser
       super
     end
 
+    def on_case(*args)
+      @comment = ""
+      super
+    end
+
     def on_ident(*args)
       @comment = ""
       super

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -27,8 +27,6 @@ module RipperRubyParser
 
       @in_method_body = false
       @local_variables = []
-
-      @kept_comment = nil
     end
 
     include SexpHandlers
@@ -118,16 +116,10 @@ module RipperRubyParser
 
     def process_comment(exp)
       _, comment, inner = exp.shift 3
-      comment = @kept_comment + comment if @kept_comment
-      @kept_comment = nil
       sexp = process(inner)
       case sexp.sexp_type
       when :defs, :defn, :module, :class, :sclass
         sexp.comments = comment
-      when :iter
-        # Drop comment
-      else
-        @kept_comment = comment
       end
       sexp
     end

--- a/lib/ripper_ruby_parser/sexp_processor.rb
+++ b/lib/ripper_ruby_parser/sexp_processor.rb
@@ -124,6 +124,8 @@ module RipperRubyParser
       case sexp.sexp_type
       when :defs, :defn, :module, :class, :sclass
         sexp.comments = comment
+      when :iter
+        # Drop comment
       else
         @kept_comment = comment
       end

--- a/ripper_ruby_parser.gemspec
+++ b/ripper_ruby_parser.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-minitest", "~> 0.36.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.2"
   spec.add_development_dependency "rubocop-performance", "~> 1.19"
-  spec.add_development_dependency "ruby_parser", "~> 3.20.2"
+  spec.add_development_dependency "ruby_parser", "~> 3.21.0"
   # Ensure sexp_processor's test cases match version 3.18.0 of ruby_parser.
   spec.add_development_dependency "sexp_processor", "~> 4.16"
   spec.add_development_dependency "simplecov", "~> 0.22.0"

--- a/test/ripper_ruby_parser/parser_test.rb
+++ b/test/ripper_ruby_parser/parser_test.rb
@@ -392,7 +392,7 @@ describe RipperRubyParser::Parser do
                                s(:call, s(:self), :class),
                                s(:defn, :class, s(:args), s(:nil)))
         _(result.comments).must_equal "# Foo\n"
-        _(result[4].comments).must_equal "# Bar\n# Baz\n"
+        _(result[4].comments).must_equal "# Baz\n"
       end
 
       it "drops comments on BEGIN blocks" do
@@ -426,6 +426,15 @@ describe RipperRubyParser::Parser do
         _(result[1].comments).must_be_nil
         _(result[2].comments).must_equal "# Foo\n"
         _(result[2][3].comments).must_equal "# foo\n"
+      end
+
+      it "drops comments on require statements" do
+        result = parser.parse "# Bar\nrequire \"foo\"\n# Foo\ndef foo; end"
+        _(result).must_equal s(:block,
+                               s(:call, nil, :require, s(:str, "foo")),
+                               s(:defn, :foo, s(:args), s(:nil)))
+        _(result.comments).must_be_nil
+        _(result[2].comments).must_equal "# Foo\n"
       end
     end
 

--- a/test/ripper_ruby_parser/parser_test.rb
+++ b/test/ripper_ruby_parser/parser_test.rb
@@ -395,31 +395,36 @@ describe RipperRubyParser::Parser do
         _(result[4].comments).must_equal "# Bar\n# Baz\n"
       end
 
-      # TODO: Prefer assigning comment to the BEGIN instead
-      it "assigns comments on BEGIN blocks to the following item" do
+      it "drops comments on BEGIN blocks" do
         result = parser.parse "# Bar\nBEGIN { }\n# Foo\ndef foo; end"
         _(result).must_equal s(:block,
                                s(:iter, s(:preexe), 0),
                                s(:defn, :foo, s(:args), s(:nil)))
-        _(result[2].comments).must_equal "# Bar\n# Foo\n"
+        _(result.comments).must_be_nil
+        _(result[1].comments).must_be_nil
+        _(result[2].comments).must_equal "# Foo\n"
       end
 
-      it "assigns comments on multiple BEGIN blocks to the following item" do
+      it "drops comments on multiple BEGIN blocks" do
         result = parser.parse "# Bar\nBEGIN { }\n# Baz\nBEGIN { }\n# Foo\ndef foo; end"
         _(result).must_equal s(:block,
                                s(:iter, s(:preexe), 0),
                                s(:iter, s(:preexe), 0),
                                s(:defn, :foo, s(:args), s(:nil)))
-        _(result[3].comments).must_equal "# Bar\n# Baz\n# Foo\n"
+        _(result[1].comments).must_be_nil
+        _(result[2].comments).must_be_nil
+        _(result[3].comments).must_equal "# Foo\n"
       end
 
-      it "assigns comments on BEGIN blocks to the first following item" do
+      it "drops comments on BEGIN blocks when followed by multiple items" do
         result = parser.parse "# Bar\nBEGIN { }\n# Foo\nclass Bar\n# foo\ndef foo; end\nend"
         _(result).must_equal s(:block,
                                s(:iter, s(:preexe), 0),
                                s(:class, :Bar, nil,
                                  s(:defn, :foo, s(:args), s(:nil))))
-        _(result[2].comments).must_equal "# Bar\n# Foo\n"
+        _(result.comments).must_be_nil
+        _(result[1].comments).must_be_nil
+        _(result[2].comments).must_equal "# Foo\n"
         _(result[2][3].comments).must_equal "# foo\n"
       end
     end

--- a/test/ripper_ruby_parser/parser_test.rb
+++ b/test/ripper_ruby_parser/parser_test.rb
@@ -434,6 +434,17 @@ describe RipperRubyParser::Parser do
                                s(:call, nil, :require, s(:str, "foo")),
                                s(:defn, :foo, s(:args), s(:nil)))
         _(result.comments).must_be_nil
+        _(result[1].comments).must_be_nil
+        _(result[2].comments).must_equal "# Foo\n"
+      end
+
+      it "drops comments on string literals" do
+        result = parser.parse "# Bar\n\"bar\"\n# Foo\nclass Foo; end"
+        _(result).must_equal s(:block,
+                               s(:str, "bar"),
+                               s(:class, :Foo, nil))
+        _(result.comments).must_be_nil
+        _(result[1].comments).must_be_nil
         _(result[2].comments).must_equal "# Foo\n"
       end
     end

--- a/test/ripper_ruby_parser/parser_test.rb
+++ b/test/ripper_ruby_parser/parser_test.rb
@@ -468,6 +468,24 @@ describe RipperRubyParser::Parser do
                                s(:defn, :bar, s(:args), s(:call, nil, :baz)))
         _(result[2].comments).must_equal "# bar\n"
       end
+
+      it "drops comments before if condition containing begin .. end" do
+        result = parser.parse <<-RUBY
+          # Foo
+          if begin foo end
+            bar
+          end
+
+          # bar
+          def bar
+            baz
+          end
+        RUBY
+        _(result).must_equal s(:block,
+                               s(:if, s(:call, nil, :foo), s(:call, nil, :bar), nil),
+                               s(:defn, :bar, s(:args), s(:call, nil, :baz)))
+        _(result[2].comments).must_equal "# bar\n"
+      end
     end
 
     # NOTE: differences in the handling of line numbers are not caught by

--- a/test/ripper_ruby_parser/parser_test.rb
+++ b/test/ripper_ruby_parser/parser_test.rb
@@ -447,6 +447,27 @@ describe RipperRubyParser::Parser do
         _(result[1].comments).must_be_nil
         _(result[2].comments).must_equal "# Foo\n"
       end
+
+      it "drops comments before and inside case statements" do
+        result = parser.parse <<-RUBY
+          # Foo
+          case foo
+          when 'bar'
+            # this is dropped
+          end
+
+          # bar
+          def bar
+            baz
+          end
+        RUBY
+        _(result).must_equal s(:block,
+                               s(:case, s(:call, nil, :foo),
+                                 s(:when, s(:array, s(:str, "bar")), nil),
+                                 nil),
+                               s(:defn, :bar, s(:args), s(:call, nil, :baz)))
+        _(result[2].comments).must_equal "# bar\n"
+      end
     end
 
     # NOTE: differences in the handling of line numbers are not caught by

--- a/test/samples/misc.rb
+++ b/test/samples/misc.rb
@@ -311,7 +311,6 @@ class Bar
 
   # Foo
   def def
-    # Bar
-    self.def.def;
+    self.def.def
   end
 end


### PR DESCRIPTION
- Update `ruby_parser` requirement from ~> 3.20.2 to ~> 3.21.0
- Declare new compatibility target in the README
- Drop comments on BEGIN blocks instead of assigning them to the following item
- Clear comment-in-progress when encountering `@ident` nodes
- Skip comments on string literals
- Remove comment that triggers an edge case from sample
- Prevent comments inside case statements from attaching to later def nodes
- Never pass comments to a next node
